### PR TITLE
Make it so that scraper modules can be found

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -79,6 +79,7 @@ class Command(BaseCommand):
             sys.excepthook = _tb_info
 
     def get_jurisdiction(self, module_name):
+        sys.path.insert(0, os.getcwd())
         # get the jurisdiction object
         module = importlib.import_module(module_name)
         for obj in module.__dict__.values():


### PR DESCRIPTION
`python -m pupa.cli update foo` works without this code, but `pupa update foo` does not (unless maybe if you are in the `pupa` directory I guess).
