### PR TITLE
Passing self to init is not necessary and causes errors

### DIFF
--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -25,7 +25,7 @@ class Scraper(scrapelib.Scraper):
     def __init__(self, jurisdiction, session, output_dir, cache_dir=None,
                  strict_validation=True, fastmode=False):
 
-        super(Scraper, self).__init__(self)
+        super(Scraper, self).__init__()
 
         self.skipped = 0
 


### PR DESCRIPTION
e.g. `TypeError: 'ExamplePersonScraper' object is not iterable`, because scrapelib thinks `self` is a list of headers...
