### PR TITLE
Correctly set the ID of the person in the roll call

### DIFF
--- a/pupa/importers/votes.py
+++ b/pupa/importers/votes.py
@@ -32,6 +32,6 @@ class VoteImporter(BaseImporter):
             if person_obj is None:
                 self.warning("Can't resolve person `%s'" % (who['name']))
             else:
-                vote['id'] = person
+                vote['person']['id'] = person_obj['_id']
 
         return obj


### PR DESCRIPTION
`person` is undefined in the current code, and `vote['id']` should be `vote['person']['id']` by my reading.
