### PR TITLE
'jurisdiction' should be a valid classification.

### DIFF
--- a/pupa/models/schemas/organization.py
+++ b/pupa/models/schemas/organization.py
@@ -1,6 +1,6 @@
 from .common import links, contact_details, identifiers, other_names, sources
 
-CLASSIFICATIONS = ['legislature', 'party', 'committee', 'commission']
+CLASSIFICATIONS = ['jurisdiction', 'legislature', 'party', 'committee', 'commission']
 
 schema = {
     "properties": {


### PR DESCRIPTION
Either that, or stop using "jurisdiction" as a classification and switch to "legislature". "jurisdiction" is used internally. It seems you don't validate documents that are created automatically by Pupa?
