### PR TITLE
Return the update report, for scripts that call the command programmatically

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -274,3 +274,4 @@ class Command(BaseCommand):
 
         # XXX: save report instead of printing
         print(report)
+        return report


### PR DESCRIPTION
I have a script that calls the update command from Python. It would be great to be able to just get the report as the return value instead of having to check standard output.
