### PR TITLE
Update schema for recent changes to Popolo

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-experimental WIP - more to come soon

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Pupa: A legislative data scraping framework
+
+## Popolo
+
+Pupa implements the Person, Organization, Membership and Post models from the [Popolo data specification](http://popoloproject.com/). Notably, it:
+
+* does not implement an `id` property, instead using `_id` from MongoDB, with the exception of the `id` property on the Post model
+* does not implement [name components](http://popoloproject.com/specs/person/name-component.html) on the Person model, with the exception of `sort_name`
+* does not implement a top-level `email` property on the Person model, instead using the `contact_details` property for all contact information
+* does not implement a `sources` property on the Membership model
+* does not implement `created_at`, `updated_at` or `sources` properties on the Post model
+* requires the `name` property on the Person and Organization models, and the `label` property on the Post model
+* does not implement [embedded JSON documents](http://popoloproject.com/specs/#embedded-json-documents), with the exception of the `posts` property on the Organization model

--- a/pupa/models/schemas/membership.py
+++ b/pupa/models/schemas/membership.py
@@ -5,25 +5,37 @@ schema = {
     "description": "A relationship between a person and an organization",
     "id": "http://popoloproject.com/schemas/membership.json#",
     "properties": {
-        # **updated_at** - the time that this object was last updated.
-        "updated_at": {"type": ["string", "datetime"], "required": False},
-        # **created_at** - the time that this object was first created.
-        "created_at": {"type": ["string", "datetime"], "required": False},
+        "updated_at": {
+            "description": "The time at which the resource was last modified",
+            "type": ["string", "datetime", "null"],
+        },
+        "created_at": {
+            "description": "The time at which the resource was created",
+            "type": ["string", "datetime", "null"],
+        },
 
         "organization_id": {
             "description": "The ID of the organization that is a party to the relationship",
-            "type": "string"
+            "type": "string",
         },
         "person_id": {
             "description": "The ID of the person who is a party to the relationship",
             "type": ["string", "null"],
         },
         "post_id": {
-            "description": "Post ID key.",
+            "description": "The ID of the post held by the person in the organization through this membership",
+            "type": ["string", "null"],
+        },
+        "on_behalf_of_id": {
+            "description": "The ID of the organization on whose behalf the person is a party to the relationship",
+            "type": ["string", "null"],
+        },
+        "label": {
+            "description": "A label describing the membership",
             "type": ["string", "null"],
         },
         "role": {
-            "description": "The role that the holder of the post fulfills",
+            "description": "The role that the person fulfills in the organization",
             "type": ["string", "null"],
         },
         "start_date": {

--- a/pupa/models/schemas/organization.py
+++ b/pupa/models/schemas/organization.py
@@ -5,7 +5,7 @@ CLASSIFICATIONS = ['legislature', 'party', 'committee', 'commission']
 schema = {
     "properties": {
         "classification": {
-            "description": "The type of organization represented by this entity.",
+            "description": "An organization category, e.g. committee",
             "type": ["string", "null"],
             "enum": CLASSIFICATIONS,
         },
@@ -20,11 +20,14 @@ schema = {
             "type": ["string", "null"],
         },
 
-        'updated_at': {"type": ["string", "datetime"], "required": False,
-                    "description": "the time that the object was last updated",
-                   },
-        'created_at': {"type": ["string", "datetime"], "required": False,
-                    "description": "the time that this object was first created" },
+        "updated_at": {
+            "description": "The time at which the resource was last modified",
+            "type": ["string", "datetime", "null"],
+        },
+        "created_at": {
+            "description": "The time at which the resource was created",
+            "type": ["string", "datetime", "null"],
+        },
 
         "identifiers": identifiers,
         "other_names": other_names,
@@ -36,12 +39,15 @@ schema = {
             "type": "string"
         },
         "parent_id": {
-            "description": "Open Civic Data ID of organization that contains this organization.",
+            "description": "The ID of the organization that contains this organization",
+            "type": ["string", "null"],
+        },
+        "image": {
+            "description": "A URL of an image",
             "type": ["string", "null"],
         },
         "posts": {
-            "description": ("Positions that exist independently of the person holding them. "
-                            "(such as chairman or minority whip)"),
+            "description": "Posts within the organization",
             "items": {
                 "properties": {
                     "contact_details": contact_details,
@@ -51,7 +57,7 @@ schema = {
                         "type": ["string", "null"],
                     },
                     "label": {
-                        "description": "A label describing the post.",
+                        "description": "A label describing the post",
                         "type": "string"
                     },
                     "organization_id": {
@@ -59,16 +65,16 @@ schema = {
                         "type": ["string", "null"],
                     },
                     "role": {
-                        "description": "The role that the holder of the post fulfills",
+                        "description": "The function that the holder of the post fulfills",
                         "type": ["string", "null"],
                     },
                     "start_date": {
-                        "description": "Startting date of the post.",
+                        "description": "The date on which the post was created",
                         "pattern": "^[0-9]{4}(-[0-9]{2}){0,2}$",
                         "type": ["string", "null"],
                     },
                     "end_date": {
-                        "description": "Ending date of the post.",
+                        "description": "The date on which the post was eliminated",
                         "pattern": "^[0-9]{4}(-[0-9]{2}){0,2}$",
                         "type": ["string", "null"],
                     },

--- a/pupa/models/schemas/person.py
+++ b/pupa/models/schemas/person.py
@@ -11,11 +11,14 @@ schema = {
         ('Common Fields', ('updated_at', 'created_at', 'sources')),
     ),
     "properties": {
-        'updated_at': {"type": ["string", "datetime"], "required": False,
-                    "description": "the time that the object was last updated",
-                   },
-        'created_at': {"type": ["string", "datetime"], "required": False,
-                    "description": "the time that this object was first created" },
+        "updated_at": {
+            "description": "The time at which the resource was last modified",
+            "type": ["string", "datetime", "null"],
+        },
+        "created_at": {
+            "description": "The time at which the resource was created",
+            "type": ["string", "datetime", "null"],
+        },
         "biography": {
             "description": "An extended account of a person's life",
             "type": ["string", "null"],
@@ -34,15 +37,6 @@ schema = {
             "description": "A gender",
             "type": ["string", "null"],
         },
-        # reinstate these?
-        #"honorific_prefix": {
-        #    "description": "One or more honorifics preceding a person's name",
-        #    "type": ["string", "null"],
-        #},
-        #"honorific_suffix": {
-        #    "description": "One or more honorifics following a person's name",
-        #    "type": ["string", "null"],
-        #},
         "image": {
             "description": "A URL of a head shot",
             "format": "uri",
@@ -50,11 +44,11 @@ schema = {
         },
         "name": {
             "description": "A person's preferred full name",
-            "type": "string"
+            "type": "string",
         },
         "sort_name": {
             "description": "A name to use in a lexicographically ordered list",
-            "type": "string"
+            "type": "string",
         },
         "contact_details": contact_details,
         "other_names": other_names,
@@ -62,6 +56,10 @@ schema = {
         "identifiers": identifiers,
         "summary": {
             "description": "A one-line account of a person's life",
+            "type": ["string", "null"],
+        },
+        "national_identity": {
+            "description": "A national identity",
             "type": ["string", "null"],
         },
         "sources": sources,


### PR DESCRIPTION
There are a few new properties in Popolo which you may choose not to add, but I added them for now:
- Person#national_identity
- Organization#image
- Membership#label
- Membership#on_behalf_of_id

A few questions:
- Shouldn't `person_id` have type `"string"` instead of `["string", "null"]` on the Membership model?
- Shouldn't `sort_name` have type `["string", "null"]` instead of `"string"` on the Person model?
- What is the reasoning for having an `organization_id` property on each Post? Won't it always be equal to the embedding organization's ID?

Besides that, I updated a few property descriptions to match Popolo.
