### PR TITLE
Update Event schema to have note array (as in OCDEP4)

### DIFF
--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -11,7 +11,7 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
             "related_entities": [],
             "subjects": [],
             "media": [],
-            "notes": "",
+            "notes": [],
             "order": None,
         })
         self.event = event

--- a/pupa/scrape/schemas/event.py
+++ b/pupa/scrape/schemas/event.py
@@ -309,7 +309,11 @@ schema = {
                     "notes": {
                         "description": ("Notes taken during this agenda"
                                         " item, may be used to construct meeting minutes."),
-                        "type": "string", "blank": True,
+                        "items": {
+                            "type": "string",
+                        },
+                        "type": "array",
+                        "minItems": 0,
                     },
 
                     "related_entities": {


### PR DESCRIPTION
http://opencivicdata.readthedocs.org/en/latest/proposals/0004.html#id1

```
    notes
        List of strings, which store any notes taken during the event while discussing this item.
```

Just changing a string to a list of strings. Anyone see an issue here?
