### PR TITLE
Check to see if a field is present before using it.

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -44,6 +44,11 @@ def items_differ(jsonitems, dbitems, subfield_dict):
         for i, jsonitem in enumerate(jsonitems):
             # check if all keys (excluding subfields) match
             for k in keys:
+                # First pass; do they both contain the key?
+                if k not in subfield_dict and (hasattr(dbitem, k) != k in jsonitem):
+                    break
+
+                # Now, do they match?
                 if k not in subfield_dict and getattr(dbitem, k) != jsonitem[k]:
                     break
             else:


### PR DESCRIPTION
@jamesturk I'm still a bit shaky in this part of the code; was getting:

``` python
    if items_differ(jsonsubitems, dbsubitems, subfield_dict[k][2]):
  File "/home/tag/dev/sunlight/pupa/pupa/importers/base.py", line 52, in items_differ
    if k not in subfield_dict and getattr(dbitem, k) != jsonitem[k]:
KeyError: 'organization_id'
```

After this, it's much happier. Unsure what the best bet here is

(Also, now that I look at it, if we have null in both that might break, is there a case where we can get a key that's not present in each? My gut says no)
