### PR TITLE
Fall back to 'None' if a key isn't present in the JSON item

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -44,7 +44,7 @@ def items_differ(jsonitems, dbitems, subfield_dict):
         for i, jsonitem in enumerate(jsonitems):
             # check if all keys (excluding subfields) match
             for k in keys:
-                if k not in subfield_dict and getattr(dbitem, k) != jsonitem[k]:
+                if k not in subfield_dict and getattr(dbitem, k) != jsonitem.get(k, None):
                     break
             else:
                 # all fields match so far, possibly equal, just check subfields now


### PR DESCRIPTION
  If the JSON dict doesn't have an element, compare it against the DB
  by defaulting to 'None', since it'd be in the db as a 'NULL' record.

Unsure if this is correct. Putting this up to think about it for a minute. Tests pass, but I'm still not 100% sure.

This fixes a bug in some of the Open States scrapers.
