### PR TITLE
Check cwd for pupa_settings

### DIFF
--- a/pupa/settings.py
+++ b/pupa/settings.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import sys
 import dj_database_url
 
 DATABASE_URL = os.environ.get('DATABASE_URL', 'postgis://pupa:pupa@localhost/opencivicdata')
@@ -62,11 +63,13 @@ LOGGING = {
 }
 
 
+sys.path.insert(1, os.getcwd())
 loader = importlib.find_loader('pupa_settings')
 if loader is None:
     print('no pupa_settings on path, using defaults')
 else:
     from pupa_settings import *     # NOQA
+sys.path.pop(1)
 
 
 DATABASES = {'default': dj_database_url.parse(DATABASE_URL)}


### PR DESCRIPTION
When I run the `pupa` command line script, it doesn't find my `pupa_settings` because it doesn't check cwd.

Note I insert at index 1 of `sys.path` because index 0 has [special meaning](https://docs.python.org/3/library/sys.html#sys.path).
