### PR TITLE
Add a default get_organizations implementation

### DIFF
--- a/pupa/scrape/jurisdiction.py
+++ b/pupa/scrape/jurisdiction.py
@@ -49,7 +49,7 @@ class Jurisdiction(BaseModel):
         return self.name
 
     def get_organizations(self):
-        raise NotImplementedError('get_organizations is not implemented')   # pragma: no cover
+        return []
 
 
 class JurisdictionScraper(Scraper):


### PR DESCRIPTION
I'd rather not have to add 114 empty methods for all our scrapers.
