### PR TITLE
Update example get_organizations to yield an object, not return an array

### DIFF
--- a/pupa/cli/commands/init.py
+++ b/pupa/cli/commands/init.py
@@ -30,7 +30,7 @@ def write_jurisdiction_template(dirname, short_name, long_name, division_id, cla
     lines.append('    }')
     lines.append('')
     lines.append('    def get_organizations(self):')
-    lines.append('        return []')
+    lines.append('        yield Organization(name=None, classification=None)')
     lines.append('')
 
     with open(os.path.join(dirname, '__init__.py'), 'w') as of:


### PR DESCRIPTION
Users may be confused and return objects instead of yielding them. Plus this implementation is often what you want.
