### PR TITLE
Rename primary_org to classification to make clear what value is expected

### DIFF
--- a/pupa/scrape/popolo.py
+++ b/pupa/scrape/popolo.py
@@ -77,7 +77,7 @@ class Person(BaseModel, SourceMixin, ContactDetailMixin, LinkMixin, IdentifierMi
     def __init__(self, name, *, birth_date='', death_date='', biography='', summary='', image='',
                  gender='', national_identity='',
                  # specialty fields
-                 district=None, party=None, primary_org='', start_date='', end_date=''):
+                 district=None, party=None, classification='', start_date='', end_date=''):
         super(Person, self).__init__()
         self.name = name
         self.birth_date = birth_date
@@ -87,8 +87,8 @@ class Person(BaseModel, SourceMixin, ContactDetailMixin, LinkMixin, IdentifierMi
         self.image = image
         self.gender = gender
         self.national_identity = national_identity
-        if primary_org:
-            self.add_term('member', primary_org, district=district,
+        if classification:
+            self.add_term('member', classification, district=district,
                           start_date=start_date, end_date=end_date)
         if party:
             self.add_party(party)

--- a/pupa/tests/scrape/test_people_org_scrape.py
+++ b/pupa/tests/scrape/test_people_org_scrape.py
@@ -91,7 +91,7 @@ def test_org_add_post():
 
 
 def test_legislator_related_district():
-    l = Person('John Adams', district='1', primary_org='legislature')
+    l = Person('John Adams', district='1', classification='legislature')
     l.pre_save('jurisdiction-id')
 
     assert len(l._related) == 1
@@ -103,7 +103,7 @@ def test_legislator_related_district():
 
 
 def test_legislator_related_chamber_district():
-    l = Person('John Adams', district='1', primary_org='upper')
+    l = Person('John Adams', district='1', classification='upper')
     l.pre_save('jurisdiction-id')
 
     assert len(l._related) == 1


### PR DESCRIPTION
Reading `primary_org` I figured an Organization was the expected value. It's actually an organization classification value that is expected.
