### PR TITLE
use name instead of _scraped_name for legislative sessions

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -167,11 +167,8 @@ class Command(BaseCommand):
 
         # copy the list to avoid modifying it
         sessions = list(juris.ignored_scraped_sessions)
-        # add _scraped_names
         for session in juris.legislative_sessions:
-            sn = session.get('_scraped_name')
-            if sn:
-                sessions.append(sn)
+            sessions.append(session['name'])
 
         unaccounted_sessions = list(set(scraped_sessions) - set(sessions))
         if unaccounted_sessions:


### PR DESCRIPTION
`legislative_sessions` support on Jurisdiction is currently busted.

`check_session_list` requires a `_scraped_name` key, but this key is not removed before importing, causing LegislativeSession creation to fail. I think `get_session_list` should just return the real, actual name and forget about scraped names. If that method needs to have a hardcoded dictionary mapping the scraped names to the correct names, do it - it just means moving the hardcoding from the `legislative_sessions` array to the method, with the benefit that you don't need to muck around later popping `_scraped_name` off a deep-clone of the `legislative_sessions` list.