### PR TITLE
don't run Sunlight-specific bill identifier cleanup

### DIFF
--- a/pupa/utils/generic.py
+++ b/pupa/utils/generic.py
@@ -29,7 +29,6 @@ _mi_bill_id_re = re.compile(r'(SJR|HJR)\s*([A-Z]+)')
 
 
 def fix_bill_id(bill_id):
-    bill_id = bill_id.replace('.', '')
     # special case for MI Joint Resolutions
     if _mi_bill_id_re.match(bill_id):
         return _mi_bill_id_re.sub(r'\1 \2', bill_id, 1).strip()


### PR DESCRIPTION
What can I say - I like my periods.

Also, in Toronto, the removed line would cause collisions between `2011.CC11.1` and `2011.CC1.11`.