### PR TITLE
Allow pseudo IDs in the sponsor ID fields

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
         post_importer = PostImporter(juris.jurisdiction_id, org_importer)
         membership_importer = MembershipImporter(juris.jurisdiction_id, person_importer,
                                                  org_importer, post_importer)
-        bill_importer = BillImporter(juris.jurisdiction_id, org_importer)
+        bill_importer = BillImporter(juris.jurisdiction_id, org_importer, person_importer)
         vote_importer = VoteImporter(juris.jurisdiction_id, person_importer, org_importer,
                                      bill_importer)
         event_importer = EventImporter(juris.jurisdiction_id)

--- a/pupa/importers/bills.py
+++ b/pupa/importers/bills.py
@@ -63,6 +63,15 @@ class BillImporter(BaseImporter):
                     entity['organization_id'] = self.org_importer.resolve_json_id(
                         entity['organization_id'])
 
+        for sponsor in data['sponsorships']:
+            if 'person_id' in sponsor:
+                sponsor['person_id'] = self.person_importer.resolve_json_id(
+                    sponsor['person_id'])
+
+            if 'organization_id' in sponsor:
+                sponsor['organization_id'] = self.person_importer.resolve_json_id(
+                    sponsor['organization_id'])
+
         return data
 
     def postimport(self):

--- a/pupa/importers/bills.py
+++ b/pupa/importers/bills.py
@@ -25,9 +25,10 @@ class BillImporter(BaseImporter):
                      }
     preserve_order = {'actions'}
 
-    def __init__(self, jurisdiction_id, org_importer):
+    def __init__(self, jurisdiction_id, org_importer, person_importer):
         super(BillImporter, self).__init__(jurisdiction_id)
         self.org_importer = org_importer
+        self.person_importer = person_importer
 
     def get_object(self, bill):
         spec = {

--- a/pupa/importers/people.py
+++ b/pupa/importers/people.py
@@ -35,6 +35,15 @@ class PersonImporter(BaseImporter):
 
         return dicts
 
+    def limit_spec(self, spec):
+        """
+        Whenever we do a Pseudo ID lookup from the database, we need to limit
+        based on the memberships -> organization -> jurisdiction, so we scope
+        the resolution.
+        """
+        spec['memberships__organization__jurisdiction_id'] = self.jurisdiction_id
+        return spec
+
     def get_object(self, person):
         all_names = [person['name']] + [o['name'] for o in person['other_names']]
         matches = list(self.model_class.objects.filter(

--- a/pupa/scrape/bill.py
+++ b/pupa/scrape/bill.py
@@ -77,6 +77,13 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
             sp[entity_type + '_id'] = entity_id
         self.sponsorships.append(sp)
 
+    def add_sponsorship_by_identifier(self, name, classification, entity_type,
+                                      primary, *, scheme, identifier, chamber=None):
+        return self.add_sponsorship(name, classification, entity_type, primary,
+                                    chamber=chamber, entity_id=make_pseudo_id(
+                                      identifiers__scheme=scheme,
+                                      identifiers__identifier=identifier))
+
     def add_subject(self, subject):
         self.subject.append(subject)
 

--- a/pupa/tests/importers/test_vote_importer.py
+++ b/pupa/tests/importers/test_vote_importer.py
@@ -29,7 +29,7 @@ def test_full_vote():
     vote.no('Adam Smith')
 
     dmi = DumbMockImporter()
-    bi = BillImporter('jid', dmi)
+    bi = BillImporter('jid', dmi, dmi)
 
     VoteImporter('jid', dmi, dmi, bi).import_data([vote.as_dict()])
 
@@ -61,7 +61,7 @@ def test_vote_identifier_dedupe():
                       identifier='Roll Call No. 1',
                      )
     dmi = DumbMockImporter()
-    bi = BillImporter('jid', dmi)
+    bi = BillImporter('jid', dmi, dmi)
 
     _, what = VoteImporter('jid', dmi, dmi, bi).import_item(vote.as_dict())
     assert what == 'insert'
@@ -101,7 +101,7 @@ def test_vote_bill_id_dedupe():
                       bill=bill.identifier, bill_chamber='lower'
                      )
     dmi = DumbMockImporter()
-    bi = BillImporter('jid', dmi)
+    bi = BillImporter('jid', dmi, dmi)
 
     _, what = VoteImporter('jid', dmi, dmi, bi).import_item(vote.as_dict())
     assert what == 'insert'
@@ -141,7 +141,7 @@ def test_vote_bill_clearing():
     bill2 = Bill.objects.create(id='bill-2', identifier='HB 2', legislative_session=session,
                                 from_organization=org)
     dmi = DumbMockImporter()
-    bi = BillImporter('jid', dmi)
+    bi = BillImporter('jid', dmi, dmi)
 
     vote1 = ScrapeVote(legislative_session='1900', start_date='2013',
                        classification='anything', result='passed',


### PR DESCRIPTION
These series of commits is here to solve #160 


The `BillImporter` has been changed to be aware of the `PersonImporter`. Existing interface code (I'm looking at you, `opencivicdata.org`) will need to change to match.

`limit_spec` for `PersonImporter` has been implemented with something suitably generic. Test-case is in place to test that.

I've added the original feature, as well - to resolve people by `identifiers.identifier`. I've credited @crdunwel on that commit, since it's his work (but faked the commit, sorry, Clay :+1: )