### PR TITLE
Upgrade tests from Django 1.7 RC to 1.7 full, in line with the other OCD repos

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-https://www.djangoproject.com/download/1.7c2/tarball/#egg=django
+Django>=1.7,<1.8
 dj_database_url
 django-uuidfield
 djorm-pgarray


### PR DESCRIPTION
This should be the last of 'em.