### PR TITLE
made importer pseudo_id mismatch error more informative

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -113,7 +113,7 @@ class BaseImporter(object):
     def postimport(self):
         pass
 
-    def resolve_json_id(self, json_id):
+    def resolve_json_id(self, json_id,data=None):
         """
             Given an id found in scraped JSON, return a DB id for the object.
 
@@ -137,11 +137,11 @@ class BaseImporter(object):
                 try:
                     self.pseudo_id_cache[json_id] = self.model_class.objects.get(**spec).id
                 except self.model_class.DoesNotExist:
-                    raise UnresolvedIdError('cannot resolve pseudo id to {}: {}'.format(
-                        self.model_class.__name__, json_id))
+                    raise UnresolvedIdError('cannot resolve pseudo id to {}: {}.\nFull data: {}'.format(
+                        self.model_class.__name__, json_id, data))
                 except self.model_class.MultipleObjectsReturned:
-                    raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}'.format(
-                        self.model_class.__name__, json_id))
+                    raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}.\nFull data:'.format(
+                        self.model_class.__name__, json_id, data))
 
             # return the cached object
             return self.pseudo_id_cache[json_id]

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -113,7 +113,7 @@ class BaseImporter(object):
     def postimport(self):
         pass
 
-    def resolve_json_id(self, json_id,data=None):
+    def resolve_json_id(self, json_id, data=None):
         """
             Given an id found in scraped JSON, return a DB id for the object.
 
@@ -140,7 +140,7 @@ class BaseImporter(object):
                     raise UnresolvedIdError('cannot resolve pseudo id to {}: {}.\nFull data: {}'.format(
                         self.model_class.__name__, json_id, data))
                 except self.model_class.MultipleObjectsReturned:
-                    raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}.\nFull data:'.format(
+                    raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}.\nFull data: {}'.format(
                         self.model_class.__name__, json_id, data))
 
             # return the cached object

--- a/pupa/importers/bills.py
+++ b/pupa/importers/bills.py
@@ -53,24 +53,24 @@ class BillImporter(BaseImporter):
 
         if data['from_organization']:
             data['from_organization_id'] = self.org_importer.resolve_json_id(
-                data.pop('from_organization'))
+                data.pop('from_organization'),data)
 
         for action in data['actions']:
             action['organization_id'] = self.org_importer.resolve_json_id(
-                action['organization_id'])
+                action['organization_id'],data)
             for entity in action['related_entities']:
                 if 'organization_id' in entity:
                     entity['organization_id'] = self.org_importer.resolve_json_id(
-                        entity['organization_id'])
+                        entity['organization_id'],data)
 
         for sponsor in data['sponsorships']:
             if 'person_id' in sponsor:
                 sponsor['person_id'] = self.person_importer.resolve_json_id(
-                    sponsor['person_id'])
+                    sponsor['person_id'],data)
 
             if 'organization_id' in sponsor:
                 sponsor['organization_id'] = self.person_importer.resolve_json_id(
-                    sponsor['organization_id'])
+                    sponsor['organization_id'],data)
 
         return data
 

--- a/pupa/importers/memberships.py
+++ b/pupa/importers/memberships.py
@@ -41,9 +41,9 @@ class MembershipImporter(BaseImporter):
             is_party = False
 
         party_flag = ('party' in data['organization_id'])
-        data['organization_id'] = self.org_importer.resolve_json_id(data['organization_id'])
-        data['person_id'] = self.person_importer.resolve_json_id(data['person_id'])
-        data['post_id'] = self.post_importer.resolve_json_id(data['post_id'])
+        data['organization_id'] = self.org_importer.resolve_json_id(data['organization_id'],data)
+        data['person_id'] = self.person_importer.resolve_json_id(data['person_id'],data)
+        data['post_id'] = self.post_importer.resolve_json_id(data['post_id'],data)
         if not is_party:
             # track that we had a membership for this person
             self.seen_person_ids.add(data['person_id'])

--- a/pupa/importers/organizations.py
+++ b/pupa/importers/organizations.py
@@ -29,7 +29,7 @@ class OrganizationImporter(BaseImporter):
         return self.model_class.objects.get(**spec)
 
     def prepare_for_db(self, data):
-        data['parent_id'] = self.resolve_json_id(data['parent_id'])
+        data['parent_id'] = self.resolve_json_id(data['parent_id'],data)
 
         if data['classification'] != 'party':
             data['jurisdiction_id'] = self.jurisdiction_id

--- a/pupa/importers/posts.py
+++ b/pupa/importers/posts.py
@@ -14,7 +14,7 @@ class PostImporter(BaseImporter):
         self.org_importer = org_importer
 
     def prepare_for_db(self, data):
-        data['organization_id'] = self.org_importer.resolve_json_id(data['organization_id'])
+        data['organization_id'] = self.org_importer.resolve_json_id(data['organization_id'],data)
         return data
 
     def get_object(self, post):

--- a/pupa/importers/votes.py
+++ b/pupa/importers/votes.py
@@ -51,7 +51,7 @@ class VoteImporter(BaseImporter):
 
     def prepare_for_db(self, data):
         data['legislative_session_id'] = self.get_session_id(data.pop('legislative_session'))
-        data['organization_id'] = self.org_importer.resolve_json_id(data.pop('organization'))
+        data['organization_id'] = self.org_importer.resolve_json_id(data.pop('organization'),data)
         data['bill_id'] = self.bill_importer.resolve_json_id(data.pop('bill'))
         return data
 


### PR DESCRIPTION
we're getting a lot of pseudo_id errors (doesn't match any, or matches more than one), but since they happen during import, it's very hard to track down the source. I dumped all the data we know about the item into the error message.