### PR TITLE
Experimental Kafka reporting

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -35,16 +35,18 @@ def print_report(report):
 
 
 def forward_report(report, jurisdiction):
+    if not settings.ENABLE_KAFKA:
+        return
+
     from kafka.client import KafkaClient
     from kafka.producer import SimpleProducer
 
-    client = KafkaClient("localhost:9092")
+    client = KafkaClient(settings.KAFKA_SERVER)  # "localhost:9092")
     producer = SimpleProducer(client)
     producer.send_messages(
-        'post-scrape-reports',
+        settings.KAFKA_REPORT_TOPIC,
         json.dumps({"jurisdiction": jurisdiction,
-                    "report": {k: v['records']
-                                for (k, v) in report['import'].items()},
+                    "report": report,
                     "type": "report"},
                    cls=utils.JSONEncoderPlus).encode())
 

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -6,7 +6,7 @@ import uuid
 import logging
 import datetime
 from pupa.exceptions import DuplicateItemError
-from pupa.utils import get_pseudo_id
+from pupa.utils import get_pseudo_id, utcnow
 from pupa.utils.topsort import Network
 from opencivicdata.models import LegislativeSession
 from pupa.exceptions import UnresolvedIdError, DataImportError
@@ -191,7 +191,7 @@ class BaseImporter(object):
         # keep counts of all actions
         record = {
             'insert': 0, 'update': 0, 'noop': 0,
-            'start': datetime.datetime.utcnow(),
+            'start': utcnow(),
             'records': {
                 'insert': [],
                 'update': [],
@@ -208,7 +208,7 @@ class BaseImporter(object):
         # all objects are loaded, a perfect time to do inter-object resolution and other tasks
         self.postimport()
 
-        record['end'] = datetime.datetime.utcnow()
+        record['end'] = utcnow()
 
         return {self._type: record}
 

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -192,11 +192,17 @@ class BaseImporter(object):
         record = {
             'insert': 0, 'update': 0, 'noop': 0,
             'start': datetime.datetime.utcnow(),
+            'records': {
+                'insert': [],
+                'update': [],
+                'noop': [],
+            }
         }
 
         for json_id, data in self._prepare_imports(data_items):
             obj_id, what = self.import_item(data)
             self.json_to_db_id[json_id] = obj_id
+            record['records'][what].append(obj_id)
             record[what] += 1
 
         # all objects are loaded, a perfect time to do inter-object resolution and other tasks

--- a/pupa/settings.py
+++ b/pupa/settings.py
@@ -9,6 +9,10 @@ INSTALLED_APPS = ('opencivicdata.apps.BaseConfig', 'pupa',)
 
 # scrape settings
 
+ENABLE_KAFKA = False
+KAFKA_REPORT_TOPIC = 'post-scrape-reports'
+KAFKA_SERVER = "localhost:9092"
+
 SCRAPELIB_RPM = 60
 SCRAPELIB_TIMEOUT = 60
 SCRAPELIB_RETRY_ATTEMPTS = 3

--- a/pupa/settings.py
+++ b/pupa/settings.py
@@ -9,7 +9,7 @@ INSTALLED_APPS = ('opencivicdata.apps.BaseConfig', 'pupa',)
 
 # scrape settings
 
-ENABLE_KAFKA = False
+ENABLE_KAFKA = os.environ.get('ENABLE_KAFKA', "False").lower() == "true"
 KAFKA_REPORT_TOPIC = 'post-scrape-reports'
 KAFKA_SERVER = "localhost:9092"
 

--- a/pupa/utils/__init__.py
+++ b/pupa/utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 from .generic import (make_pseudo_id, get_pseudo_id, makedirs, fix_bill_id, DatetimeValidator,
-                      JSONEncoderPlus, convert_pdf)
+                      JSONEncoderPlus, convert_pdf, utcnow)

--- a/pupa/utils/generic.py
+++ b/pupa/utils/generic.py
@@ -8,6 +8,9 @@ import subprocess
 from validictory.validator import SchemaValidator
 
 
+def utcnow():
+    return datetime.datetime.now(datetime.timezone.utc)
+
 def make_pseudo_id(**kwargs):
     """ pseudo ids are just JSON """
     return '~' + json.dumps(kwargs)


### PR DESCRIPTION
This will forward all pupa reports along on Kafka if doing an import.

This will solve #173 - also enables https://github.com/paultag/sunlight-scratch/blob/master/kafka-forward.py

Should settings-gate it out.

Reviews / ACKs? @rshorey @mileswwatkins @boblannon @apendleton