### PR TITLE
fix almost all flake8 errors

### DIFF
--- a/pupa/cli/commands/dbinit.py
+++ b/pupa/cli/commands/dbinit.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         self.add_argument('--reset', action='store_true', default=False,
                           help='reset entire database - USE WITH CAUTION')
         self.add_argument('--partial-reset', action='store_true', default=False,
-                          help='reset entire database, except for divisions - STILL, USE WITH CAUTION')
+                          help='reset entire database, except for divisions - USE WITH CAUTION')
         self.add_argument(type=str, dest='country', nargs='+',
                           help='country to load divisions for')
 

--- a/pupa/cli/commands/dump.py
+++ b/pupa/cli/commands/dump.py
@@ -4,7 +4,7 @@ import requests
 import boto
 
 from ... import settings
-from .base import BaseCommand, CommandError
+from .base import BaseCommand
 
 
 def parse_page(url):
@@ -13,8 +13,8 @@ def parse_page(url):
     data = requests.get(url + '&apikey=' + settings.API_KEY).json()
     for person in data['results']:
         id = person['id']
-        pjson = requests.get('https://api.opencivicdata.org/{}/?apikey={}'.format(id,
-                                                                                  settings.API_KEY))
+        pjson = requests.get('https://api.opencivicdata.org/{}/?apikey={}'.format(
+            id, settings.API_KEY))
         with open(id, 'w') as f:
             f.write(pjson.text)
     page = data['meta']['page'] + 1
@@ -45,7 +45,6 @@ class Command(BaseCommand):
 
     def add_args(self):
         pass
-        #self.add_argument('module', type=str, help='name of the new scraper module')
 
     def handle(self, args, other):
         bucket = 'allthe.opencivicdata.org'

--- a/pupa/cli/commands/init.py
+++ b/pupa/cli/commands/init.py
@@ -5,6 +5,7 @@ from .base import BaseCommand, CommandError
 from opencivicdata.common import JURISDICTION_CLASSIFICATIONS
 from opencivicdata.divisions import Division
 
+
 def prompt(ps, default=''):
     return input(ps).strip() or default
 
@@ -42,10 +43,11 @@ def write_jurisdiction_template(dirname, short_name, long_name, division_id, cla
     lines.append('        org = Organization(name="org_name", classification="legislature")')
     lines.append('')
 
-    lines.append('        #OPTIONAL: add posts to your organizaion using thi format,')
-    lines.append('        #where label is a human-readable description of the post (eg "Ward 8 conucilmember")')
-    lines.append('        #and role is the positoin type (eg conucilmember, alderman, mayor...)')
-    lines.append('        #skip entirely if you\'re not writing a people scraper.')
+    lines.append('        # OPTIONAL: add posts to your organizaion using thi format,')
+    lines.append('        # where label is a human-readable description of the post '
+                 '(eg "Ward 8 councilmember")')
+    lines.append('        # and role is the positoin type (eg conucilmember, alderman, mayor...)')
+    lines.append('        # skip entirely if you\'re not writing a people scraper.')
     lines.append('        org.add_post(label="position_description", role="position_type")')
     lines.append('')
     lines.append('        #REQUIIRED: yield the organization')
@@ -81,7 +83,8 @@ class Command(BaseCommand):
     def handle(self, args, other):
 
         name = prompt('jurisdiction name (e.g. City of Seattle): ')
-        division = prompt('division id (look this up in the opencivicdata/ocd-division-ids repository): ')
+        division = prompt('division id (look this up in the opencivicdata/ocd-division-ids '
+                          'repository): ')
         classification = prompt('classification (can be: {}): '
                                 .format(', '.join(JURISDICTION_CLASSIFICATIONS)))
         url = prompt('official URL: ')
@@ -89,10 +92,10 @@ class Command(BaseCommand):
         try:
             Division.get(division)
         except ValueError:
-            print("\nERROR: Division ID is invalid.",\
-                    "Please find the correct division_id here",\
-                    "https://github.com/opencivicdata/ocd-division-ids/tree/master/identifiers",\
-                    "or contact open-civic-data@googlegroups.org to add a new country\n")
+            print("\nERROR: Division ID is invalid.",
+                  "Please find the correct division_id here",
+                  "https://github.com/opencivicdata/ocd-division-ids/tree/master/identifiers",
+                  "or contact open-civic-data@googlegroups.org to add a new country\n")
             sys.exit(1)
 
         if os.path.exists(args.module):

--- a/pupa/exceptions.py
+++ b/pupa/exceptions.py
@@ -24,6 +24,7 @@ class NoMembershipsError(DataImportError):
             len(ids), ', '.join(ids))
         )
 
+
 class SameNameError(DataImportError):
     """ Attempt was made to import two people with the same name. """
 
@@ -37,8 +38,8 @@ class DuplicateItemError(DataImportError):
     """ Attempt was made to import items that resolve to the same database item. """
 
     def __init__(self, data, obj):
-        super(DuplicateItemError, self).__init__('attempt to import data that would conflict with data '
-                                                 'already in the import: {} '
+        super(DuplicateItemError, self).__init__('attempt to import data that would conflict with '
+                                                 'data already in the import: {} '
                                                  '(already imported as {})'.format(
                                                      data, obj))
 

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -2,12 +2,9 @@ import os
 import copy
 import glob
 import json
-import uuid
 import logging
-import datetime
 from pupa.exceptions import DuplicateItemError
 from pupa.utils import get_pseudo_id, utcnow
-from pupa.utils.topsort import Network
 from opencivicdata.models import LegislativeSession
 from pupa.exceptions import UnresolvedIdError, DataImportError
 
@@ -140,8 +137,10 @@ class BaseImporter(object):
                     raise UnresolvedIdError('cannot resolve pseudo id to {}: {}'.format(
                         self.model_class.__name__, json_id))
                 except self.model_class.MultipleObjectsReturned:
-                    raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}'.format(
-                        self.model_class.__name__, json_id))
+                    raise UnresolvedIdError(
+                        'multiple objects returned for pseudo id to {}: {}'.format(
+                            self.model_class.__name__, json_id)
+                    )
 
             # return the cached object
             return self.pseudo_id_cache[json_id]
@@ -259,8 +258,6 @@ class BaseImporter(object):
             self._create_related(obj, related, self.related_models)
 
         return obj.id, what
-
-
 
     def _update_related(self, obj, related, subfield_dict):
         """

--- a/pupa/importers/bills.py
+++ b/pupa/importers/bills.py
@@ -1,6 +1,6 @@
 from pupa.utils import fix_bill_id
 from opencivicdata.models import (Bill, RelatedBill, BillAbstract, BillTitle, BillIdentifier,
-                                  BillAction, BillActionRelatedEntity, RelatedBill,
+                                  BillAction, BillActionRelatedEntity,
                                   BillSponsorship, BillSource, BillDocument, BillVersion,
                                   BillDocumentLink, BillVersionLink)
 from .base import BaseImporter

--- a/pupa/importers/events.py
+++ b/pupa/importers/events.py
@@ -1,6 +1,3 @@
-import pytz
-import datetime
-
 from .base import BaseImporter
 from ..utils.event import read_event_iso_8601
 from opencivicdata.models import (Event, EventLocation, EventSource, EventDocument,
@@ -41,7 +38,6 @@ class EventImporter(BaseImporter):
             'jurisdiction_id': self.jurisdiction_id
         }
         return self.model_class.objects.get(**spec)
-
 
     def get_location(self, location_data):
         obj, created = EventLocation.objects.get_or_create(name=location_data['name'],

--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -2,7 +2,6 @@ import os
 import json
 import uuid
 import logging
-import datetime
 from collections import defaultdict, OrderedDict
 
 import scrapelib

--- a/pupa/scrape/bill.py
+++ b/pupa/scrape/bill.py
@@ -44,7 +44,6 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
         self.abstracts = []
         self.versions = []
 
-
     def add_action(self, description, date, *, organization=None, chamber=None,
                    classification=None, related_entities=None):
         action = Action(description=description, date=date,
@@ -81,8 +80,8 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
                                       primary, *, scheme, identifier, chamber=None):
         return self.add_sponsorship(name, classification, entity_type, primary,
                                     chamber=chamber, entity_id=make_pseudo_id(
-                                      identifiers__scheme=scheme,
-                                      identifiers__identifier=identifier))
+                                    identifiers__scheme=scheme,
+                                    identifiers__identifier=identifier))
 
     def add_subject(self, subject):
         self.subject.append(subject)

--- a/pupa/scrape/bill.py
+++ b/pupa/scrape/bill.py
@@ -80,8 +80,9 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
                                       primary, *, scheme, identifier, chamber=None):
         return self.add_sponsorship(name, classification, entity_type, primary,
                                     chamber=chamber, entity_id=make_pseudo_id(
-                                    identifiers__scheme=scheme,
-                                    identifiers__identifier=identifier))
+                                        identifiers__scheme=scheme,
+                                        identifiers__identifier=identifier)
+                                    )
 
     def add_subject(self, subject):
         self.subject.append(subject)

--- a/pupa/scrape/popolo.py
+++ b/pupa/scrape/popolo.py
@@ -77,7 +77,8 @@ class Person(BaseModel, SourceMixin, ContactDetailMixin, LinkMixin, IdentifierMi
     def __init__(self, name, *, birth_date='', death_date='', biography='', summary='', image='',
                  gender='', national_identity='',
                  # specialty fields
-                 district=None, party=None, primary_org='', role='member', start_date='', end_date=''):
+                 district=None, party=None, primary_org='', role='member',
+                 start_date='', end_date=''):
         super(Person, self).__init__()
         self.name = name
         self.birth_date = birth_date

--- a/pupa/tests/django_settings.py
+++ b/pupa/tests/django_settings.py
@@ -10,4 +10,4 @@ DATABASES = {
         'HOST': 'localhost',
     }
 }
-MIDDLEWARE_CLASSES=()
+MIDDLEWARE_CLASSES = ()

--- a/pupa/tests/importers/test_base_importer.py
+++ b/pupa/tests/importers/test_base_importer.py
@@ -75,7 +75,6 @@ def test_exception_on_identical_objects_in_import_stream():
     o1 = ScrapeOrganization('X-Men', classification='unknown').as_dict()
     o2 = ScrapeOrganization('X-Men', founding_date='1970', classification='unknown').as_dict()
 
-    pi = OrganizationImporter('jid')
     with pytest.raises(Exception):
         OrganizationImporter('jid').import_data([o1, o2])
 

--- a/pupa/tests/importers/test_event_importer.py
+++ b/pupa/tests/importers/test_event_importer.py
@@ -1,8 +1,7 @@
 import pytest
-import datetime as dt
 from pupa.scrape import Event as ScrapeEvent
 from pupa.importers import EventImporter
-from opencivicdata.models import Event, Jurisdiction
+from opencivicdata.models import Jurisdiction
 
 
 def ge():
@@ -18,7 +17,7 @@ def ge():
 
 @pytest.mark.django_db
 def test_related_people_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -31,11 +30,11 @@ def test_related_people_event():
 
     result = EventImporter('jid').import_data([event2.as_dict()])
     assert result['event']['noop'] == 1
-    
+
 
 @pytest.mark.django_db
 def test_related_vote_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -52,7 +51,7 @@ def test_related_vote_event():
 
 @pytest.mark.django_db
 def test_related_bill_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -69,7 +68,7 @@ def test_related_bill_event():
 
 @pytest.mark.django_db
 def test_related_committee_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -86,7 +85,7 @@ def test_related_committee_event():
 
 @pytest.mark.django_db
 def test_media_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -106,8 +105,8 @@ def test_media_event():
 
 
 @pytest.mark.django_db
-def test_media_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+def test_media_document():
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1 = ge()
     event2 = ge()
 
@@ -124,7 +123,7 @@ def test_media_event():
 
 @pytest.mark.django_db
 def test_full_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event = ge()
 
     result = EventImporter('jid').import_data([event.as_dict()])
@@ -141,9 +140,9 @@ def test_full_event():
 
 @pytest.mark.django_db
 def test_bad_event_time():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event = ge()
-    event.start_time="2014-07-04T05:00"
+    event.start_time = "2014-07-04T05:00"
     pytest.raises(
         ValueError,
         EventImporter('jid').import_item,
@@ -153,7 +152,7 @@ def test_bad_event_time():
 
 @pytest.mark.django_db
 def test_top_level_media_event():
-    j = Jurisdiction.objects.create(id='jid', division_id='did')
+    Jurisdiction.objects.create(id='jid', division_id='did')
     event1, event2 = ge(), ge()
 
     event1.add_media_link("fireworks", "http://example.com/fireworks.mov",

--- a/pupa/tests/importers/test_membership_importer.py
+++ b/pupa/tests/importers/test_membership_importer.py
@@ -5,6 +5,7 @@ from pupa.importers import MembershipImporter, PersonImporter
 from pupa.exceptions import NoMembershipsError
 from opencivicdata.models import Organization, Post, Person
 
+
 class DumbMockImporter(object):
     """ this is a mock importer that implements a resolve_json_id that is just a pass-through """
     json_to_db_id = {}
@@ -51,8 +52,8 @@ def test_full_membership():
 
 @pytest.mark.django_db
 def test_no_membership_for_person():
-    org = Organization.objects.create(id="fnd", name="Foundation", classification="foundation",
-                                      jurisdiction_id="fnd-jid")
+    Organization.objects.create(id="fnd", name="Foundation", classification="foundation",
+                                jurisdiction_id="fnd-jid")
 
     # import a person with no memberships
     p = ScrapePerson('a man without a country')
@@ -73,9 +74,9 @@ def test_no_membership_for_person_including_party():
     even though party is specified we should still get a no memberships error because it doesn't
     bind the person to a jurisdiction, thus causing duplication
     """
-    org = Organization.objects.create(id="fnd", name="Foundation", classification="foundation",
-                                      jurisdiction_id="fnd-jid")
-    org = Organization.objects.create(id="dem", name="Democratic", classification="party")
+    Organization.objects.create(id="fnd", name="Foundation", classification="foundation",
+                                jurisdiction_id="fnd-jid")
+    Organization.objects.create(id="dem", name="Democratic", classification="party")
 
     # import a person with no memberships
     p = ScrapePerson('a man without a country', party='Democratic')

--- a/pupa/tests/importers/test_organization_importer.py
+++ b/pupa/tests/importers/test_organization_importer.py
@@ -104,6 +104,7 @@ def test_pseudo_ids():
     assert (oi2.resolve_json_id('~{"classification":"international", "name":"United Nations"}') ==
             un.id)
 
+
 @pytest.mark.django_db
 def test_parent_id_resolution():
     parent = ScrapeOrganization('UN', classification='international')

--- a/pupa/tests/importers/test_people_importer.py
+++ b/pupa/tests/importers/test_people_importer.py
@@ -4,6 +4,7 @@ from pupa.importers import PersonImporter
 from opencivicdata.models import Person, Organization, Membership
 from pupa.exceptions import SameNameError
 
+
 @pytest.mark.django_db
 def test_full_person():
     person = ScrapePerson('Tom Sawyer')
@@ -148,10 +149,11 @@ def test_same_name_people():
     assert resp['person']['noop'] == 0
     assert resp['person']['update'] == 1
 
+
 @pytest.mark.django_db
 def test_same_name_people_other_name():
     # ensure we're taking other_names into account for the name collision code
-    o = Organization.objects.create(name='WWE', jurisdiction_id='jurisdiction-id')
+    Organization.objects.create(name='WWE', jurisdiction_id='jurisdiction-id')
     p1 = ScrapePerson('Dwayne Johnson', image='http://example.com/1')
     p2 = ScrapePerson('Rock', image='http://example.com/2')
     p2.add_name('Dwayne Johnson')
@@ -171,7 +173,7 @@ def test_same_name_second_import():
     p2.birth_date = '1930'
 
     # when we give them birth dates all is well though
-    resp = PersonImporter('jurisdiction-id').import_data([p1.as_dict(), p2.as_dict()])
+    PersonImporter('jurisdiction-id').import_data([p1.as_dict(), p2.as_dict()])
 
     # fake some memberships so future lookups work on these people
     for p in Person.objects.all():
@@ -180,4 +182,4 @@ def test_same_name_second_import():
     p3 = ScrapePerson('Dwayne Johnson', image='http://example.com/3')
 
     with pytest.raises(SameNameError):
-        resp = PersonImporter('jurisdiction-id').import_data([p3.as_dict()])
+        PersonImporter('jurisdiction-id').import_data([p3.as_dict()])

--- a/pupa/tests/importers/test_vote_importer.py
+++ b/pupa/tests/importers/test_vote_importer.py
@@ -15,11 +15,11 @@ class DumbMockImporter(object):
 def test_full_vote():
     j = Jurisdiction.objects.create(id='jid', division_id='did')
     session = j.legislative_sessions.create(name='1900', identifier='1900')
-    person = Person.objects.create(id='person-id', name='Adam Smith')
+    Person.objects.create(id='person-id', name='Adam Smith')
     org = Organization.objects.create(id='org-id', name='House', classification='lower')
     bill = Bill.objects.create(id='bill-id', identifier='HB 1', legislative_session=session,
                                from_organization=org)
-    com = Organization.objects.create(id='com-id', name='Arbitrary Committee', parent=org)
+    Organization.objects.create(id='com-id', name='Arbitrary Committee', parent=org)
 
     vote = ScrapeVote(legislative_session='1900', motion_text='passage', start_date='1900-04-01',
                       classification='passage:bill', result='pass', bill_chamber='lower',
@@ -53,13 +53,12 @@ def test_full_vote():
 @pytest.mark.django_db
 def test_vote_identifier_dedupe():
     j = Jurisdiction.objects.create(id='jid', division_id='did')
-    session = j.legislative_sessions.create(name='1900', identifier='1900')
+    j.legislative_sessions.create(name='1900', identifier='1900')
 
     vote = ScrapeVote(legislative_session='1900', start_date='2013',
                       classification='anything', result='passed',
                       motion_text='a vote on something',
-                      identifier='Roll Call No. 1',
-                     )
+                      identifier='Roll Call No. 1')
     dmi = DumbMockImporter()
     bi = BillImporter('jid', dmi, dmi)
 
@@ -98,8 +97,7 @@ def test_vote_bill_id_dedupe():
     vote = ScrapeVote(legislative_session='1900', start_date='2013',
                       classification='anything', result='passed',
                       motion_text='a vote on something',
-                      bill=bill.identifier, bill_chamber='lower'
-                     )
+                      bill=bill.identifier, bill_chamber='lower')
     dmi = DumbMockImporter()
     bi = BillImporter('jid', dmi, dmi)
 
@@ -122,8 +120,7 @@ def test_vote_bill_id_dedupe():
     vote = ScrapeVote(legislative_session='1900', start_date='2013',
                       classification='anything', result='passed',
                       motion_text='a vote on something',
-                      bill=bill2.identifier, bill_chamber='lower'
-                     )
+                      bill=bill2.identifier, bill_chamber='lower')
     _, what = VoteImporter('jid', dmi, dmi, bi).import_item(vote.as_dict())
     assert what == 'insert'
     assert VoteEvent.objects.count() == 2
@@ -138,21 +135,19 @@ def test_vote_bill_clearing():
     org = Organization.objects.create(id='org-id', name='House', classification='lower')
     bill = Bill.objects.create(id='bill-1', identifier='HB 1', legislative_session=session,
                                from_organization=org)
-    bill2 = Bill.objects.create(id='bill-2', identifier='HB 2', legislative_session=session,
-                                from_organization=org)
+    Bill.objects.create(id='bill-2', identifier='HB 2', legislative_session=session,
+                        from_organization=org)
     dmi = DumbMockImporter()
     bi = BillImporter('jid', dmi, dmi)
 
     vote1 = ScrapeVote(legislative_session='1900', start_date='2013',
                        classification='anything', result='passed',
-                       motion_text='a vote on somthing', # typo intentional
-                       bill=bill.identifier, bill_chamber='lower'
-                     )
+                       motion_text='a vote on somthing',             # typo intentional
+                       bill=bill.identifier, bill_chamber='lower')
     vote2 = ScrapeVote(legislative_session='1900', start_date='2013',
                        classification='anything', result='passed',
                        motion_text='a vote on something else',
-                       bill=bill.identifier, bill_chamber='lower'
-                     )
+                       bill=bill.identifier, bill_chamber='lower')
 
     # have to use import_data so postimport is called
     VoteImporter('jid', dmi, dmi, bi).import_data([vote1.as_dict(), vote2.as_dict()])

--- a/pupa/tests/scrape/test_bill_scrape.py
+++ b/pupa/tests/scrape/test_bill_scrape.py
@@ -24,7 +24,8 @@ def test_bill_type_setting():
     assert b.classification == ["bill"]
 
     # string -> list
-    b = Bill(identifier="some bill", legislative_session="session", title="the title", classification="string")
+    b = Bill(identifier="some bill", legislative_session="session", title="the title",
+             classification="string")
     assert b.classification == ["string"]
 
     # list unmodified

--- a/pupa/tests/scrape/test_event_scrape.py
+++ b/pupa/tests/scrape/test_event_scrape.py
@@ -54,7 +54,7 @@ def test_agenda_add_vote():
     e = event_obj()
     agenda = e.add_agenda_item("foo bar")
     assert agenda['related_entities'] == []
-    
+
     agenda.add_vote(vote='Roll no. 12')
     assert len(e.agenda[0]['related_entities']) == 1
     e.validate()
@@ -118,7 +118,8 @@ def test_participants():
 
 def test_set_location():
     e = event_obj()
-    e.set_location('North Pole', note='it is cold here', coordinates={'latitude': '90.0000', 'longitude': '0.0000'})
+    e.set_location('North Pole', note='it is cold here',
+                   coordinates={'latitude': '90.0000', 'longitude': '0.0000'})
 
     assert e.location.get('name') == 'North Pole'
     assert e.location.get('note') == 'it is cold here'

--- a/pupa/utils/event.py
+++ b/pupa/utils/event.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import pytz
 
 
 EVENT_TIME_FORMATS = [

--- a/pupa/utils/generic.py
+++ b/pupa/utils/generic.py
@@ -1,6 +1,5 @@
 import re
 import os
-import time
 import json
 import pytz
 import datetime
@@ -10,6 +9,7 @@ from validictory.validator import SchemaValidator
 
 def utcnow():
     return datetime.datetime.now(datetime.timezone.utc)
+
 
 def make_pseudo_id(**kwargs):
     """ pseudo ids are just JSON """

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,4 @@ commands = flake8 pupa
 [flake8]
 max-line-length = 99
 ignore = E124
+exclude = pupa/migrations,pupa/scrape/schemas

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,4 @@ commands = flake8 pupa
 
 [flake8]
 max-line-length = 99
+ignore = E124


### PR DESCRIPTION
noticed this when working on the django 1.8 branch, a lot of noise here made keeping things flake8 hard

this leaves two flake8 errors both of which are interesting and possibly bugs

pupa/importers/memberships.py:43:9: F841 local variable 'party_flag' is assigned to but never used
pupa/importers/organizations.py:50:9: F841 local variable 'pseudo_children' is assigned to but never used

we should probably take a look at these two before just blindly fixing them
