### PR TITLE
Don't silently swallow errors

### DIFF
--- a/pupa/cli/__main__.py
+++ b/pupa/cli/__main__.py
@@ -33,7 +33,8 @@ def main():
 
     try:
         django.setup()
-    except django.db.utils.OperationalError:
+    except django.db.utils.OperationalError as e:
+        logger.warning('django.setup() failed with exception "%s"', e)
         pass
 
     subcommands = {}


### PR DESCRIPTION
When you do want to have a DB (e.g. when running `pupa dbinit`), it helps to see the errors from `django.setup()`.

See #87 where the try/except was added.