### PR TITLE
Allows resolutions of people with memberships in multiple sub jurisdiction organizations

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -140,11 +140,11 @@ class BaseImporter(object):
                 elif not ids :
                     raise UnresolvedIdError(
                         'cannot resolve pseudo id to {}: {}'.format(
-                        self.model_class.__name__, json_id))
+                            self.model_class.__name__, json_id))
                 else :
                     raise UnresolvedIdError(
                         'multiple objects returned for pseudo id to {}: {}'.format(
-                        self.model_class.__name__, json_id))
+                            self.model_class.__name__, json_id))
 
             # return the cached object
             return self.pseudo_id_cache[json_id]

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -134,12 +134,16 @@ class BaseImporter(object):
             if json_id not in self.pseudo_id_cache:
                 spec = get_pseudo_id(json_id)
                 spec = self.limit_spec(spec)
-                try:
-                    self.pseudo_id_cache[json_id] = self.model_class.objects.get(**spec).id
-                except self.model_class.DoesNotExist:
+
+                ids = {each.id 
+                       for each 
+                       in self.model_class.objects.filter(**spec)}
+                if len(ids) == 1 :
+                    self.pseudo_id_cache[json_id] = ids.pop()
+                elif not ids :
                     raise UnresolvedIdError('cannot resolve pseudo id to {}: {}'.format(
                         self.model_class.__name__, json_id))
-                except self.model_class.MultipleObjectsReturned:
+                else :
                     raise UnresolvedIdError('multiple objects returned for pseudo id to {}: {}'.format(
                         self.model_class.__name__, json_id))
 


### PR DESCRIPTION
Right now if you have a person who is a member of "City Council" and "Committee on Finance" for that committee then: 

```python
self.model_class.objects.get(name='Jane Doe', 
                             memberships__organization__jurisdiction_id='ocdjurisdiction/country:us/state:ny/place:new_york/government').id
```

Fails with a `MultipleObjectsReturned` error. This is because the `memberships__organizations__jurisdiction_id` parameter will cause Django to return an object for **each** membership in an organization within a jurisdiction id. Since Jane Doe is both a member of the council and a committee and both are under the same jurisdiction, Jane's object will be returned twice.

This pull request handles that by allowing for multiple objects to be returned and then checking to make sure that there is one and only one unique_id associated with all those objects.