### PR TITLE
pull ocd-django from github instead of pypi

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,5 @@ pytest
 pytest-cov
 pytest-django
 coveralls
+
+-e git://github.com/sunlightlabs/waterfall.git#egg=waterfall

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ dj_database_url
 django-uuidfield
 djorm-pgarray
 jsonfield==0.9.20
-opencivicdata-django
+-e git://github.com/opencivicdata/python-opencivicdata-django.git#egg=opencivicdata-django
 psycopg2
 scrapelib
 validictory


### PR DESCRIPTION
pointing at an old version of pypi, shld probably fix pypi at some point but this quick fix will work.