### PR TITLE
Add classification field to EventAgendaItem

### DIFF
--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -9,7 +9,7 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
     def __init__(self, description, event):
         super(EventAgendaItem, self).__init__({
             "description": description,
-            "classification": str(),
+            "classification": [],
             "related_entities": [],
             "subjects": [],
             "media": [],

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -9,6 +9,7 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
     def __init__(self, description, event):
         super(EventAgendaItem, self).__init__({
             "description": description,
+            "classification": str(),
             "related_entities": [],
             "subjects": [],
             "media": [],

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -21,6 +21,9 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
     def add_subject(self, what):
         self['subjects'].append(what)
 
+    def add_classification(self, what):
+        self['classification'].append(what)
+
     def add_vote_event(self, vote_event, *, id=None, note='consideration'):
         self.add_entity(name=vote_event, entity_type='vote_event', id=id, note=note)
 

--- a/pupa/scrape/schemas/event.py
+++ b/pupa/scrape/schemas/event.py
@@ -132,6 +132,10 @@ schema = {
                 "properties": {
                     "description": { "type": "string", },
 
+                    "classification": {
+                        "type": ["string", "null"],
+                    },
+
                     "order": {
                         "type": ["string", "null"],
                     },

--- a/pupa/scrape/schemas/event.py
+++ b/pupa/scrape/schemas/event.py
@@ -133,7 +133,8 @@ schema = {
                     "description": { "type": "string", },
 
                     "classification": {
-                        "type": ["string", "null"],
+                        "items": {"type": "string"},
+                        "type": "array",
                     },
 
                     "order": {

--- a/pupa/tests/scrape/test_event_scrape.py
+++ b/pupa/tests/scrape/test_event_scrape.py
@@ -71,6 +71,17 @@ def test_agenda_add_subject():
 
     e.validate()
 
+def test_agenda_add_classification():
+    e = event_obj()
+    agenda = e.add_agenda_item("foo bar")
+
+    agenda.add_classification('test')
+    assert e.agenda[0]['classification'] == ['test']
+    agenda.add_classification('test2')
+    assert e.agenda[0]['classification'] == ['test', 'test2']
+
+    e.validate()
+
 
 def test_add_committee():
     e = event_obj()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 Django>=1.9
-opencivicdata-django==0.8.0
+-e git+ssh://git@github.com/opencivicdata/python-opencividata-django.git@master#egg=opencivicdata-django-0.8.3a
 
 dj_database_url
 psycopg2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 Django>=1.9
--e git+ssh://git@github.com/opencivicdata/python-opencividata-django.git@master#egg=opencivicdata-django-0.8.3a
+-e git+https://github.com/opencivicdata/python-opencivicdata-django.git@master#egg=opencivicdata-django
 
 dj_database_url
 psycopg2


### PR DESCRIPTION
This is reticketed from here https://github.com/opencivicdata/scrapers-ca/pull/168#issuecomment-173796717

Presumably I would start with a PR to [`opencivicdata/python-opencivicdata-django`](https://github.com/opencivicdata/python-opencivicdata-django/blob/master/opencivicdata/models/event.py), but it seemed to make most sense to ask for a blessing here first :)

Would adding a classification to agenda items be an acceptable approach?
