### PR TITLE
Org name resolution on Person.add_membership

### DIFF
--- a/pupa/scrape/popolo.py
+++ b/pupa/scrape/popolo.py
@@ -95,13 +95,19 @@ class Person(BaseModel, SourceMixin, ContactDetailMixin, LinkMixin, IdentifierMi
         if party:
             self.add_party(party)
 
-    def add_membership(self, organization, role='member', **kwargs):
+    def add_membership(self, name_or_org, role='member', **kwargs):
         """
             add a membership in an organization and return the membership
             object in case there are more details to add
         """
-        membership = Membership(person_id=self._id, organization_id=organization._id,
-                                role=role, **kwargs)
+        if isinstance(name_or_org, Organization):
+            membership = Membership(person_id=self._id,
+                                    organization_id=name_or_org._id,
+                                    role=role, **kwargs)
+        else:
+            membership = Membership(person_id=self._id,
+                                    organization_id=_make_pseudo_id(name=name_or_org),
+                                    role=role, **kwargs)
         self._related.append(membership)
         return membership
 

--- a/pupa/tests/scrape/test_people_org_scrape.py
+++ b/pupa/tests/scrape/test_people_org_scrape.py
@@ -46,7 +46,7 @@ def test_basic_person():
     p.validate()
 
 
-def test_person_add_membership():
+def test_person_add_membership_org():
     p = Person('Bob B. Bear')
     p.add_source('http://example.com')
     o = Organization('test org', classification='unknown')
@@ -57,7 +57,6 @@ def test_person_add_membership():
     assert p._related[0].organization_id == o._id
     assert p._related[0].start_date == '2007'
     assert p._related[0].end_date == datetime.date(2015, 5, 8)
-
 
 def test_basic_organization():
     org = Organization('some org', classification='committee')
@@ -143,3 +142,12 @@ def test_committee_add_member_name():
     assert get_pseudo_id(c._related[0].person_id) == {'name': 'John Adams'}
     assert c._related[0].organization_id == c._id
     assert c._related[0].role == 'member'
+
+def test_person_add_membership_name():
+    p = Person('Leonardo DiCaprio')
+    p.add_membership('Academy of Motion Picture Arts and Sciences', role='winner', start_date='2016')
+    p._related[0].validate()
+    assert get_pseudo_id(p._related[0].organization_id) == {'name': 'Academy of Motion Picture Arts and Sciences'}
+    assert p._related[0].person_id == p._id
+    assert p._related[0].role == 'winner'
+    assert p._related[0].start_date == '2016'


### PR DESCRIPTION
I know add_membership doesn't get used much, but I needed it for scraping LegistarOrganizationScraper when splitting the people scraper from the org scraper.

Much appreciated for considering the merge!