### PR TITLE
Relax opencivicdata-django version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pupa',
 pupa = pupa.cli.__main__:main''',
       install_requires=[
           'Django>=1.9.0',
-          'opencivicdata-django==0.8.0',
+          'opencivicdata-django>=0.8.0',
           'dj_database_url==0.3.0',
           'opencivicdata-divisions',
           'scrapelib>=1.0',


### PR DESCRIPTION
https://github.com/opencivicdata/pupa/blob/master/setup.py#L21

Right now, if I'm using a custom version of opencivicdata-django in my scrapers, I need to also use a custom pupa package in order for errors to not be thrown. Could we relax this to use `>=` rather than `==`?