### PR TITLE
Force unpacking of Python egg, for accessible Django migrations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='pupa',
       description='scraping framework for muncipal data',
       long_description=long_description,
       platforms=['any'],
+      zip_safe=False,
       entry_points='''[console_scripts]
 pupa = pupa.cli.__main__:main''',
       install_requires=[


### PR DESCRIPTION
Was setting up the OCD environment on my current machine (macOS 10.12, Python 3.5). This PR addresses one hitch I hit while setting up the Pupa environment:

- `python setup.py install`ing Pupa in the virtualenv does install the Python Egg, however only as binary, not as an unzipped directory
- Django, when running `pupa dbinit ${your favorite country}`, expects `site-packages/pupa-${version}.egg` to _not_ be a binary, so that it can access the `pupa/migrations` inside it as a directory; otherwise, it throws a `NotADirectoryError`
- Re-`setup.py`ing Pupa after adding `zip_safe=False` to `setup()` makes everything work properly.

This could be my own misunderstanding of Python packaging, but I ran it by @jamesturk for a sanity check. Probably just a tiny issue with environment differences.