### PR TITLE
Update on related fields if order is different

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -36,6 +36,7 @@ def items_differ(jsonitems, dbitems, subfield_dict):
         return True
 
     jsonitems = copy.deepcopy(jsonitems)
+    full_jsonitems = copy.deepcopy(jsonitems)
     keys = jsonitems[0].keys()
 
     # go over dbitems looking for matches
@@ -54,6 +55,11 @@ def items_differ(jsonitems, dbitems, subfield_dict):
                     if items_differ(jsonsubitems, dbsubitems, subfield_dict[k][2]):
                         break
                 else:
+                    order = getattr(dbitem, 'order', None)
+                    if order is not None:
+                        json_order = full_jsonitems.index(jsonitem)
+                        if int(order) != json_order:
+                            break
                     # these items are equal, so let's mark it for removal
                     match = i
                     break

--- a/pupa/tests/importers/test_bill_importer.py
+++ b/pupa/tests/importers/test_bill_importer.py
@@ -187,6 +187,16 @@ def test_bill_update_because_of_subitem():
     obj = Bill.objects.get()
     assert obj.actions.count() == 2
 
+    # same 2 actions, diiferen order, update
+    bill = ScrapeBill('HB 1', '1900', 'First Bill', chamber='lower')
+    bill.add_action('this is a second action', chamber='lower', date='1900-01-02')
+    bill.add_action('this is an action', chamber='lower', date='1900-01-01')
+    result = BillImporter('jid', oi, pi).import_data([bill.as_dict()])
+    assert result['bill']['update'] == 1
+    obj = Bill.objects.get()
+    assert obj.actions.count() == 2
+
+
     # different 2 actions, update
     bill = ScrapeBill('HB 1', '1900', 'First Bill', chamber='lower')
     bill.add_action('this is an action', chamber='lower', date='1900-01-01')


### PR DESCRIPTION
For some related fields, like bill actions, the order of the actions is meaningful. This PR makes a change to items_differ to check if order has been changed for these types of fields. 