### PR TITLE
template method for get_session_list

### DIFF
--- a/pupa/scrape/jurisdiction.py
+++ b/pupa/scrape/jurisdiction.py
@@ -42,9 +42,6 @@ class Jurisdiction(BaseModel):
                 'legislative_sessions': self.legislative_sessions,
                 'feature_flags': self.feature_flags, 'extras': self.extras, }
 
-    def get_session_list(self):
-        raise NotImplementedError('get_session_list is not implemented')    # pragma: no cover
-
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
This commit https://github.com/opencivicdata/pupa/commit/c54e8969f6dae1d3de364c31e5ee2a0cf0b69925#commitcomment-20440348 introduced a requirement that JurisdictionScraper classes have an attribute called `get_session_list`

This is a backwards incompatible change. 

I attempted to reverse this backwards incompatibility by allowing the attribute to not be defined in https://github.com/opencivicdata/pupa/commit/0b30407a634773d6e3bf8fbf07b683e10ef87c8d

However, this was not a sufficient fix because, [for a long time](https://github.com/opencivicdata/pupa/blame/master/pupa/scrape/jurisdiction.py#L45), `get_session_list` has been defined on the base `JurisdictionScraper` class.

So, unless it is explicitly deleted, then `get_session_list` always exists. And if it is not overridden in a derived class it will raise a `NotImplementedError` 

This PR changes the behavior of the method on the base class to do nothing. Other backwards-compatible behavior would be to

- delete the method
- have the method make a warning, not raise an exception