### PR TITLE
Add common args to subcommands.

### DIFF
--- a/pupa/cli/__main__.py
+++ b/pupa/cli/__main__.py
@@ -18,8 +18,8 @@ COMMAND_MODULES = (
 
 def main():
     parser = argparse.ArgumentParser('pupa', description='pupa CLI')
-    parser.add_argument('--debug', nargs='?', const='pdb', default=None,
-                        help='drop into pdb (or set =ipdb =pudb)')
+    parser.add_argument('--debug', action='store_true',
+                        help='open debugger on error')
     parser.add_argument('--loglevel', default='INFO', help=('set log level. options are: '
                                                             'DEBUG|INFO|WARNING|ERROR|CRITICAL '
                                                             '(default is INFO)'))
@@ -47,14 +47,17 @@ def main():
 
     # turn debug on
     if args.debug:
-        _debugger = importlib.import_module(args.debug)
+        try:
+            debug_module = importlib.import_module('ipdb')
+        except ImportError:
+            debug_module = importlib.import_module('pdb')
 
         # turn on PDB-on-error mode
         # stolen from http://stackoverflow.com/questions/1237379/
         # if this causes problems in interactive mode check that page
         def _tb_info(type, value, tb):
             traceback.print_exception(type, value, tb)
-            _debugger.pm()
+            debug_module.pm()
         sys.excepthook = _tb_info
 
     if not args.subcommand:


### PR DESCRIPTION
As a developer, I want to be able to tack `--debug` onto the end of a command without wasting valuable ( 😉 ) seconds scrolling back to the beginning of the line.

This also (sort of) fixes an issue with the current `--debug` flag. As implemented, it takes zero arguments (use pdb) or one (use a custom debugger). But when it's passed to the main command instead of a subcommand, it effectively must take exactly one argument--otherwise, the subcommand will be interpreted as the argument to `--debug`. In other words, users can't do this:

```
pupa --debug update ny
```

If `--debug` is accepted by subcommands, as it is in this patch, users *can* do this:

```
pupa update ny --debug
```

Which is what I wanted to do in the first place. This patch still isn't perfect, since now `--debug` takes zero or one arguments as a flag to subcommands and exactly one argument as a flag to the main command. Suggestions for a better solution welcome, but IMO this is preferable to the current implementation.