### PR TITLE
Override settings from modules and args.

### DIFF
--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -33,7 +33,7 @@ def override_settings(settings, overrides):
         setattr(settings, key, value)
     yield
     for key, value in original.items():
-        if key is UNSET:
+        if value is UNSET:
             delattr(settings, key)
         else:
             setattr(settings, key, value)

--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -5,10 +5,10 @@ import logging
 from collections import defaultdict, OrderedDict
 
 import scrapelib
-from django.conf import settings
 from validictory import ValidationError
 
 from pupa import utils
+from pupa import settings
 
 
 class ScrapeError(Exception):

--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -5,9 +5,10 @@ import logging
 from collections import defaultdict, OrderedDict
 
 import scrapelib
+from django.conf import settings
 from validictory import ValidationError
 
-from pupa import utils, settings
+from pupa import utils
 
 
 class ScrapeError(Exception):

--- a/pupa/settings.py
+++ b/pupa/settings.py
@@ -1,6 +1,7 @@
 import os
-import importlib
 import sys
+import importlib
+
 import dj_database_url
 
 DATABASE_URL = os.environ.get('DATABASE_URL', 'postgis://pupa:pupa@localhost/opencivicdata')

--- a/pupa/tests/django_settings.py
+++ b/pupa/tests/django_settings.py
@@ -1,5 +1,3 @@
-import os
-
 # django settings for tests
 SECRET_KEY = 'test'
 INSTALLED_APPS = ('opencivicdata.apps.BaseConfig',)
@@ -13,11 +11,3 @@ DATABASES = {
     }
 }
 MIDDLEWARE_CLASSES = ()
-
-SCRAPELIB_RPM = 60
-SCRAPELIB_TIMEOUT = 60
-SCRAPELIB_RETRY_ATTEMPTS = 3
-SCRAPELIB_RETRY_WAIT_SECONDS = 20
-
-CACHE_DIR = os.path.join(os.getcwd(), '_cache')
-SCRAPED_DATA_DIR = os.path.join(os.getcwd(), '_data')

--- a/pupa/tests/django_settings.py
+++ b/pupa/tests/django_settings.py
@@ -1,3 +1,5 @@
+import os
+
 # django settings for tests
 SECRET_KEY = 'test'
 INSTALLED_APPS = ('opencivicdata.apps.BaseConfig',)
@@ -11,3 +13,11 @@ DATABASES = {
     }
 }
 MIDDLEWARE_CLASSES = ()
+
+SCRAPELIB_RPM = 60
+SCRAPELIB_TIMEOUT = 60
+SCRAPELIB_RETRY_ATTEMPTS = 3
+SCRAPELIB_RETRY_WAIT_SECONDS = 20
+
+CACHE_DIR = os.path.join(os.getcwd(), '_cache')
+SCRAPED_DATA_DIR = os.path.join(os.getcwd(), '_data')

--- a/pupa/tests/scrape/test_utils.py
+++ b/pupa/tests/scrape/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pupa.cli.commands.update import override_settings
+
+class _Settings:
+    pass
+
+@pytest.fixture
+def settings():
+    ret = _Settings()
+    ret.foo = 'bar'
+    ret.baz = 'bob'
+    return ret
+
+def test_override_settings(settings):
+    with override_settings(settings, {'baz': 'fez'}):
+        assert settings.foo == 'bar'
+        assert settings.baz == 'fez'
+    assert settings.foo == 'bar'
+    assert settings.baz == 'bob'
+
+def test_override_settings_unset(settings):
+    with override_settings(settings, {'qux': 'fez'}):
+        assert settings.qux == 'fez'
+    assert not hasattr(settings, 'qux')

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,1 +1,1 @@
-export PYTHONPATH=.; py.test --cov pupa --cov-report html --ds=pupa.tests.django_settings
+export PYTHONPATH=.; pytest --cov pupa --cov-report html --ds=pupa.tests.django_settings

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py35,flake8
 [testenv]
 commands = 
  pip install -e .
- py.test pupa --ds=pupa.tests.django_settings
+ pytest pupa --ds=pupa.tests.django_settings
 deps =-rrequirements-test.txt
 
 [testenv:flake8]


### PR DESCRIPTION
Settings passed to scrapelib don't seem to do anything at the moment. This patch applies overrides from scraper modules and command-line arguments. Logic lifted from billy.