### PR TITLE
handle pseudo ids in event importer of bill ids

### DIFF
--- a/pupa/importers/events.py
+++ b/pupa/importers/events.py
@@ -1,5 +1,5 @@
 from .base import BaseImporter
-from pupa.utils import fix_bill_id
+from pupa.utils import fix_bill_id, get_pseudo_id, _make_pseudo_id
 from pupa.utils.event import read_event_iso_8601
 from opencivicdata.models import (Event, EventLocation, EventSource, EventDocument,
                                   EventDocumentLink, EventLink, EventParticipant, EventMedia,
@@ -87,8 +87,11 @@ class EventImporter(BaseImporter):
                         entity['organization_id'],
                         allow_no_match=True)
                 elif 'bill_id' in entity:
+                    bill = get_pseudo_id(entity['bill_id'])
+                    bill['identifier'] = fix_bill_id(bill['identifier'])
+                    bill = _make_pseudo_id(**bill)
                     entity['bill_id'] = self.bill_importer.resolve_json_id(
-                        fix_bill_id(entity['bill_id']),
+                        bill,
                         allow_no_match=True)
                 elif 'vote_event_id' in entity:
                     entity['vote_event_id'] = self.vote_event_importer.resolve_json_id(


### PR DESCRIPTION
In a previous PR, I added `fix_bill_ids` to help with the resolution of bill ids as related entities of event agenda items. I didn't adequately handle the pseudo id nature of these ids. This fixes that.