### PR TITLE
_scraped_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # pupa changelog
 
-## 0.6.1
+## WIP
 
 Improvements:
 
 * allow Memberships to have unresolved `person_name` similar to how other
   name resolutions work
 * add Scraper.latest\_session convienience method
+* optionally allow setting \_scraped\_name on legislative\_session, which will
+  be used in session\_list checking if present
 
 Fixes:
 

--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -226,7 +226,7 @@ class Command(BaseCommand):
         # copy the list to avoid modifying it
         sessions = set(juris.ignored_scraped_sessions)
         for session in juris.legislative_sessions:
-            sessions.add(session['identifier'])
+            sessions.add(session.get('_scraped_name', session['identifier']))
 
         unaccounted_sessions = list(set(scraped_sessions) - sessions)
         if unaccounted_sessions:

--- a/pupa/importers/jurisdiction.py
+++ b/pupa/importers/jurisdiction.py
@@ -11,3 +11,7 @@ class JurisdictionImporter(BaseImporter):
     def get_object(self, data):
         return self.model_class.objects.get(division_id=data['division_id'],
                                             classification=data['classification'])
+    def prepare_for_db(self, data):
+        for s in data['legislative_sessions']:
+            s.pop('_scraped_name', None)
+        return data


### PR DESCRIPTION
this is a bit of an odd case, lets this property be set at scrape time but not saved, will be used when session list checking occurs (useful in case the state's session identifiers are completely opaque, like internal DB ids)