### PR TITLE
Import missing classes for consistency.

### DIFF
--- a/pupa/scrape/__init__.py
+++ b/pupa/scrape/__init__.py
@@ -2,6 +2,6 @@
 from .jurisdiction import Jurisdiction, JurisdictionScraper
 from .popolo import Membership, Organization, Person, Post
 from .vote_event import VoteEvent
-from .bill import Bill
-from .event import Event
+from .bill import Action, Bill
+from .event import Event, EventAgendaItem
 from .base import Scraper, BaseBillScraper


### PR DESCRIPTION
So that I can `from pupa.scrape import EventAgendaItem`.