### PR TITLE
addresses #275

### DIFF
--- a/pupa/importers/memberships.py
+++ b/pupa/importers/memberships.py
@@ -22,7 +22,6 @@ class MembershipImporter(BaseImporter):
         spec = {'organization_id': membership['organization_id'],
                 'person_id': membership['person_id'],
                 'label': membership['label'],
-                'role' : membership['role'],
                 # if this is a historical role, only update historical roles
                 'end_date': membership['end_date']}
 


### PR DESCRIPTION
removes the line matching on role but all tests still pass

this fixes scrapers that use the ``primary_org`` helper as defined here:

https://github.com/opencivicdata/pupa/blob/master/pupa/scrape/popolo.py#L94

