### PR TITLE
consolidate exceptions a bit

### DIFF
--- a/pupa/cli/__main__.py
+++ b/pupa/cli/__main__.py
@@ -5,7 +5,7 @@ import argparse
 import importlib
 import traceback
 from django.conf import settings
-from pupa.cli.commands.base import CommandError
+from pupa.exceptions import CommandError
 
 logger = logging.getLogger('pupa')
 

--- a/pupa/cli/commands/base.py
+++ b/pupa/cli/commands/base.py
@@ -1,7 +1,3 @@
-class CommandError(Exception):
-    pass
-
-
 class BaseCommand(object):
 
     def __init__(self, subparsers):

--- a/pupa/cli/commands/init.py
+++ b/pupa/cli/commands/init.py
@@ -1,6 +1,7 @@
 import os
 
-from .base import BaseCommand, CommandError
+from .base import BaseCommand
+from pupa.exceptions import CommandError
 from opencivicdata.common import JURISDICTION_CLASSIFICATIONS
 from opencivicdata.divisions import Division
 

--- a/pupa/cli/commands/update.py
+++ b/pupa/cli/commands/update.py
@@ -12,8 +12,9 @@ from django.db import transaction
 from pupa import utils
 from pupa import settings
 from pupa.scrape import Jurisdiction, JurisdictionScraper
+from pupa.exceptions import CommandError
 
-from .base import BaseCommand, CommandError
+from .base import BaseCommand
 
 
 ALL_ACTIONS = ('scrape', 'import')

--- a/pupa/exceptions.py
+++ b/pupa/exceptions.py
@@ -8,6 +8,13 @@ class PupaInternalError(PupaError):
     """ Indication something went wrong inside of Pupa that never should happen """
 
 
+class CommandError(PupaError):
+    """ Errors from within pupa CLI """
+
+
+# import-related errors
+
+
 class DataImportError(PupaError):
     """ A generic error related to the import process. """
 
@@ -48,5 +55,12 @@ class UnresolvedIdError(DataImportError):
     """ Attempt was made to resolve an id that has no result. """
 
 
-class CommandError(PupaError):
-    """ Errors from within pupa CLI """
+# scrape-related errors
+
+
+class ScrapeError(PupaError):
+    """ A generic error related to the scrape process. """
+
+
+class ScrapeValueError(PupaError, ValueError):
+    """ An invalid value was passed to a pupa scrape object. """

--- a/pupa/exceptions.py
+++ b/pupa/exceptions.py
@@ -46,3 +46,7 @@ class DuplicateItemError(DataImportError):
 
 class UnresolvedIdError(DataImportError):
     """ Attempt was made to resolve an id that has no result. """
+
+
+class CommandError(PupaError):
+    """ Errors from within pupa CLI """

--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -9,10 +9,7 @@ from validictory import ValidationError
 
 from pupa import utils
 from pupa import settings
-
-
-class ScrapeError(Exception):
-    pass
+from pupa.exceptions import ScrapeError, ScrapeValueError
 
 
 def cleanup_list(obj, default):
@@ -178,7 +175,7 @@ class BaseModel(object):
         try:
             validator.validate(self.as_dict(), schema)
         except ValidationError as ve:
-            raise ValidationError('validation of {} {} failed: {}'.format(
+            raise ScrapeValueError('validation of {} {} failed: {}'.format(
                 self.__class__.__name__, self._id, ve)
             )
 
@@ -197,7 +194,7 @@ class BaseModel(object):
 
     def __setattr__(self, key, val):
         if key[0] != '_' and key not in self._schema['properties'].keys():
-            raise ValueError('property "{}" not in {} schema'.format(key, self._type))
+            raise ScrapeValueError('property "{}" not in {} schema'.format(key, self._type))
         super(BaseModel, self).__setattr__(key, val)
 
 
@@ -259,7 +256,7 @@ class AssociatedLinkMixin(object):
     def _add_associated_link(self, collection, note, url, *, media_type, text, on_duplicate,
                              date=''):
         if on_duplicate not in ['error', 'ignore']:
-            raise ValueError("on_duplicate must be 'error' or 'ignore'")
+            raise ScrapeValueError("on_duplicate must be 'error' or 'ignore'")
 
         try:
             associated = getattr(self, collection)
@@ -287,7 +284,7 @@ class AssociatedLinkMixin(object):
 
         if url in seen_links:
             if on_duplicate == 'error':
-                raise ValueError("Duplicate entry in '%s' - URL: '%s'" % (collection, url))
+                raise ScrapeValueError("Duplicate entry in '%s' - URL: '%s'" % (collection, url))
             else:
                 # This means we're in ignore mode. This situation right here
                 # means we should *skip* adding this link silently and continue

--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -159,8 +159,7 @@ class BaseModel(object):
         """
         Validate that we have a valid object.
 
-        On error, this will either raise a `ValueError` or a
-        `validictory.ValidationError` (a subclass of `ValueError`).
+        On error, this will raise a `ScrapeValueError`
 
         This also expects that the schemas assume that omitting required
         in the schema asserts the field is optional, not required. This is

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -1,6 +1,7 @@
 from ..utils import _make_pseudo_id
 from .base import BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin
 from .schemas.event import schema
+from pupa.exceptions import ScrapeValueError
 
 
 class EventAgendaItem(dict, AssociatedLinkMixin):
@@ -53,12 +54,11 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
         elif entity_type:
             if entity_type in ('organization', 'person'):
                 id = _make_pseudo_id(name=name)
-            elif entity_type == 'bill':
-                id = _make_pseudo_id(identifier=name)
-            elif entity_type == 'vote_event':
+            elif entity_type in ('bill', 'vote_event'):
                 id = _make_pseudo_id(identifier=name)
             else:
-                raise NotImplementedError('{} entity type not implemented'.format(entity_type))
+                raise ScrapeValueError('attempt to call add_entity with unsupported '
+                                       'entity type: {}'.format(entity_type))
             ret[entity_type + '_id'] = id
 
         self['related_entities'].append(ret)

--- a/pupa/scrape/popolo.py
+++ b/pupa/scrape/popolo.py
@@ -6,6 +6,7 @@ from .schemas.person import schema as person_schema
 from .schemas.membership import schema as membership_schema
 from .schemas.organization import schema as org_schema
 from ..utils import _make_pseudo_id
+from pupa.exceptions import ScrapeValueError
 
 # a copy of the org schema without sources
 org_schema_no_sources = copy.deepcopy(org_schema)
@@ -211,7 +212,7 @@ class Organization(BaseModel, SourceMixin, ContactDetailMixin, LinkMixin, Identi
 def pseudo_organization(organization, classification, default=None):
     """ helper for setting an appropriate ID for organizations """
     if organization and classification:
-        raise ValueError('cannot specify both classification and organization')
+        raise ScrapeValueError('cannot specify both classification and organization')
     elif classification:
         return _make_pseudo_id(classification=classification)
     elif organization:

--- a/pupa/scrape/vote_event.py
+++ b/pupa/scrape/vote_event.py
@@ -3,6 +3,7 @@ from .base import BaseModel, cleanup_list, SourceMixin
 from .bill import Bill
 from .popolo import pseudo_organization
 from .schemas.vote_event import schema
+from pupa.exceptions import ScrapeValueError
 
 
 class VoteEvent(BaseModel, SourceMixin):
@@ -30,7 +31,7 @@ class VoteEvent(BaseModel, SourceMixin):
             self.legislative_session = bill.legislative_session
 
         if not self.legislative_session:
-            raise ValueError('must set legislative_session or bill')
+            raise ScrapeValueError('must set legislative_session or bill')
 
         self.organization = pseudo_organization(organization, chamber, 'legislature')
         self.votes = []
@@ -45,7 +46,7 @@ class VoteEvent(BaseModel, SourceMixin):
             self.bill = None
         elif isinstance(bill_or_identifier, Bill):
             if chamber:
-                raise ValueError("set_bill takes no arguments when using a `Bill` object")
+                raise ScrapeValueError("set_bill takes no arguments when using a `Bill` object")
             self.bill = bill_or_identifier._id
         else:
             if chamber is None:

--- a/pupa/tests/scrape/test_bill_scrape.py
+++ b/pupa/tests/scrape/test_bill_scrape.py
@@ -1,7 +1,7 @@
 import pytest
-from validictory import ValidationError
 from pupa.scrape import Bill
 from pupa.utils.generic import get_pseudo_id
+from pupa.exceptions import ScrapeValueError
 
 
 def toy_bill():
@@ -139,7 +139,7 @@ def test_add_documents():
 
     # an invalid document
     b.add_document_link(note="Fiscal Impact", date="2013-04", url=None, media_type='foo')
-    with pytest.raises(ValidationError):
+    with pytest.raises(ScrapeValueError):
         b.validate()
 
 

--- a/pupa/tests/scrape/test_people_org_scrape.py
+++ b/pupa/tests/scrape/test_people_org_scrape.py
@@ -1,8 +1,8 @@
+import datetime
 import pytest
 from pupa.scrape import Person, Organization, Membership, Post
 from pupa.utils import get_pseudo_id
-from validictory import ValidationError
-import datetime
+from pupa.exceptions import ScrapeValueError
 
 
 def test_basic_post():
@@ -35,7 +35,7 @@ def test_basic_invalid_person():
 
     bob.name = None
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ScrapeValueError):
         bob.validate()
 
 
@@ -76,7 +76,7 @@ def test_basic_invalid_organization():
     orga = Organization("name")
 
     # no source
-    with pytest.raises(ValidationError):
+    with pytest.raises(ScrapeValueError):
         orga.validate()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,flake8
+envlist = py36,flake8
 [testenv]
 commands = 
  pip install -e .[dev] git+https://github.com/opencivicdata/python-opencivicdata.git#egg=opencivicdata


### PR DESCRIPTION
- consolidates a few places where exceptions were defined into pupa.exceptions
- the only real difference is that a lot of uses of bare ValueError are now ScrapeValueError (which does inherit from ValueError)- this makes future enhancements

hoping to lay some groundwork here for gradual improvement of error messages by catching most/all pupa-defined exceptions and printing useful error messages instead of stack traces

closes #114 