### PR TITLE
fix query for other_names

### DIFF
--- a/pupa/importers/organizations.py
+++ b/pupa/importers/organizations.py
@@ -55,7 +55,7 @@ class OrganizationImporter(BaseImporter):
         name = spec.pop('name', None)
         if name:
             return (Q(**spec) &
-                    Q(name=name) | Q(other_names__name=name))
+                    (Q(name=name) | Q(other_names__name=name)))
         return spec
 
     def _prepare_imports(self, dicts):

--- a/pupa/tests/importers/test_organization_importer.py
+++ b/pupa/tests/importers/test_organization_importer.py
@@ -104,7 +104,6 @@ def test_deduplication_error_overlaps():
     wildlife = Organization.objects.create(name='World Wildlife Fund',
                                            classification='international',
                                            jurisdiction_id='jid1')
-
     wildlife.other_names.create(name='WWF')
 
     org = ScrapeOrganization('World Wrestling Federation', classification='international')
@@ -112,6 +111,25 @@ def test_deduplication_error_overlaps():
     od = org.as_dict()
     with pytest.raises(SameOrgNameError):
         OrganizationImporter('jid1').import_data([od])
+
+
+@pytest.mark.django_db
+def test_deduplication_overlap_name_distinct_juris():
+    create_jurisdictions()
+
+    Organization.objects.create(name='World Wrestling Federation',
+                                classification='international',
+                                jurisdiction_id='jid1')
+    webforum = Organization.objects.create(name='Web Wrestling Forums',
+                                           classification='international',
+                                           jurisdiction_id='jid2')
+    webforum.other_names.create(name='WWF')
+
+    org = ScrapeOrganization('World Wrestling Federation', classification='international')
+    org.add_name('WWF')
+    od = org.as_dict()
+    OrganizationImporter('jid1').import_data([od])
+    assert Organization.objects.all().count() == 2
 
 
 @pytest.mark.django_db

--- a/pupa/tests/importers/test_organization_importer.py
+++ b/pupa/tests/importers/test_organization_importer.py
@@ -117,19 +117,17 @@ def test_deduplication_error_overlaps():
 def test_deduplication_overlap_name_distinct_juris():
     create_jurisdictions()
 
-    Organization.objects.create(name='World Wrestling Federation',
-                                classification='international',
-                                jurisdiction_id='jid1')
-    webforum = Organization.objects.create(name='Web Wrestling Forums',
-                                           classification='international',
-                                           jurisdiction_id='jid2')
-    webforum.other_names.create(name='WWF')
+    org_jid_1 = Organization.objects.create(name='World Wrestling Federation',
+                                            classification='international',
+                                            jurisdiction_id='jid1')
+    org_jid_1.other_names.create(name='WWF')
 
-    org = ScrapeOrganization('World Wrestling Federation', classification='international')
-    org.add_name('WWF')
-    od = org.as_dict()
-    OrganizationImporter('jid1').import_data([od])
-    assert Organization.objects.all().count() == 2
+    oi1 = OrganizationImporter('jid1')
+    assert oi1.resolve_json_id('~{"name":"WWF"}') == org_jid_1.id
+
+    oi1 = OrganizationImporter('jid2')
+    with pytest.raises(UnresolvedIdError):
+        assert oi1.resolve_json_id('~{"name":"WWF"}')
 
 
 @pytest.mark.django_db

--- a/pupa/tests/scrape/test_people_org_scrape.py
+++ b/pupa/tests/scrape/test_people_org_scrape.py
@@ -93,49 +93,49 @@ def test_org_add_post():
 
 
 def test_legislator_related_district():
-    l = Person('John Adams', district='1', primary_org='legislature')
-    l.pre_save('jurisdiction-id')
+    leg = Person('John Adams', district='1', primary_org='legislature')
+    leg.pre_save('jurisdiction-id')
 
-    assert len(l._related) == 1
-    assert l._related[0].person_id == l._id
-    assert get_pseudo_id(l._related[0].organization_id) == {'classification': 'legislature'}
-    assert get_pseudo_id(l._related[0].post_id) == {"organization__classification": "legislature",
-                                                    "label": "1"}
+    assert len(leg._related) == 1
+    assert leg._related[0].person_id == leg._id
+    assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'legislature'}
+    assert get_pseudo_id(leg._related[0].post_id) == {"organization__classification": "legislature",
+                                                      "label": "1"}
 
 
 def test_legislator_related_chamber_district():
-    l = Person('John Adams', district='1', primary_org='upper')
-    l.pre_save('jurisdiction-id')
+    leg = Person('John Adams', district='1', primary_org='upper')
+    leg.pre_save('jurisdiction-id')
 
-    assert len(l._related) == 1
-    assert l._related[0].person_id == l._id
-    assert get_pseudo_id(l._related[0].organization_id) == {'classification': 'upper'}
-    assert get_pseudo_id(l._related[0].post_id) == {"organization__classification": "upper",
-                                                    "label": "1"}
+    assert len(leg._related) == 1
+    assert leg._related[0].person_id == leg._id
+    assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'upper'}
+    assert get_pseudo_id(leg._related[0].post_id) == {"organization__classification": "upper",
+                                                      "label": "1"}
 
 
 def test_legislator_related_chamber_district_role():
-    l = Person('John Adams', district='1', primary_org='lower', role='Speaker')
-    l.pre_save('jurisdiction-id')
+    leg = Person('John Adams', district='1', primary_org='lower', role='Speaker')
+    leg.pre_save('jurisdiction-id')
 
-    assert len(l._related) == 1
-    assert l._related[0].person_id == l._id
-    assert get_pseudo_id(l._related[0].organization_id) == {'classification': 'lower'}
-    assert get_pseudo_id(l._related[0].post_id) == {"organization__classification": "lower",
+    assert len(leg._related) == 1
+    assert leg._related[0].person_id == leg._id
+    assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'lower'}
+    assert get_pseudo_id(leg._related[0].post_id) == {"organization__classification": "lower",
                                                     "label": "1", "role": "Speaker"}
-    assert l._related[0].role == 'Speaker'
+    assert leg._related[0].role == 'Speaker'
 
 
 def test_legislator_related_party():
-    l = Person('John Adams', party='Democratic-Republican')
-    l.pre_save('jurisdiction-id')
+    leg = Person('John Adams', party='Democratic-Republican')
+    leg.pre_save('jurisdiction-id')
 
     # a party membership
-    assert len(l._related) == 1
-    assert l._related[0].person_id == l._id
-    assert get_pseudo_id(l._related[0].organization_id) == {'classification': 'party',
+    assert len(leg._related) == 1
+    assert leg._related[0].person_id == leg._id
+    assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'party',
                                                             'name': 'Democratic-Republican'}
-    assert l._related[0].role == 'member'
+    assert leg._related[0].role == 'member'
 
 
 def test_committee_add_member_person():

--- a/pupa/tests/scrape/test_people_org_scrape.py
+++ b/pupa/tests/scrape/test_people_org_scrape.py
@@ -99,8 +99,9 @@ def test_legislator_related_district():
     assert len(leg._related) == 1
     assert leg._related[0].person_id == leg._id
     assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'legislature'}
-    assert get_pseudo_id(leg._related[0].post_id) == {"organization__classification": "legislature",
-                                                      "label": "1"}
+    assert get_pseudo_id(leg._related[0].post_id) ==\
+        {"organization__classification": "legislature",
+         "label": "1"}
 
 
 def test_legislator_related_chamber_district():
@@ -122,7 +123,7 @@ def test_legislator_related_chamber_district_role():
     assert leg._related[0].person_id == leg._id
     assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'lower'}
     assert get_pseudo_id(leg._related[0].post_id) == {"organization__classification": "lower",
-                                                    "label": "1", "role": "Speaker"}
+                                                      "label": "1", "role": "Speaker"}
     assert leg._related[0].role == 'Speaker'
 
 
@@ -134,7 +135,7 @@ def test_legislator_related_party():
     assert len(leg._related) == 1
     assert leg._related[0].person_id == leg._id
     assert get_pseudo_id(leg._related[0].organization_id) == {'classification': 'party',
-                                                            'name': 'Democratic-Republican'}
+                                                              'name': 'Democratic-Republican'}
     assert leg._related[0].role == 'member'
 
 


### PR DESCRIPTION
The query for checking other names in `limit_spec` for orgs was missing a grouping paren. Now it follows same logic as `get_object` 