### PR TITLE
Fix voteevent bill session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Improvements:
 Fixes:
 
 * bugfix for OrganizationImporter other_names
+* bugfix for VoteEvent bill resolution
 
 
 ## 0.8.0 - July 19 2017

--- a/pupa/scrape/vote_event.py
+++ b/pupa/scrape/vote_event.py
@@ -52,7 +52,9 @@ class VoteEvent(BaseModel, SourceMixin):
             if chamber is None:
                 chamber = 'legislature'
             kwargs = {'identifier': bill_or_identifier,
-                      'from_organization__classification': chamber}
+                      'from_organization__classification': chamber,
+                      'legislative_session__identifier': self.legislative_session
+                      }
             self.bill = _make_pseudo_id(**kwargs)
 
     def vote(self, option, voter, *, note=''):

--- a/pupa/tests/scrape/test_vote_event_scrape.py
+++ b/pupa/tests/scrape/test_vote_event_scrape.py
@@ -85,7 +85,9 @@ def test_set_bill_pseudo_id():
     ve = toy_vote_event()
     ve.set_bill('HB 1', chamber='lower')
     assert get_pseudo_id(ve.bill) == {'identifier': 'HB 1',
-                                      'from_organization__classification': 'lower'}
+                                      'from_organization__classification': 'lower',
+                                      'legislative_session__identifier': '2009',
+                                      }
 
 
 def test_str():


### PR DESCRIPTION
I'm a bit confused how we managed without this fix, but it appears that we don't currently add the legislative session ID to the VoteEvent.bill psuedo_id for resolution

we were getting errors like:

pupa.exceptions.UnresolvedIdError: multiple objects returned for Bill pseudo id ~{"from_organization__classification": "upper", "identifier": "SB 1"}: {'ocd-bill/4cebaa7a-087f-43ed-b5e8-ace698ddb5cf', 'ocd-bill/d79b9d92-d030-4e05-8fb3-4e9cf7830d99'}

But adding this causes legislative_session__identifier to be taken into account (set to the VoteEvent.legislative_session  and these votes resolve appropriately)