### PR TITLE
psycopg2 wheel is changing names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ pupa = pupa.cli.__main__:main''',
           'dj_database_url>=0.3.0',
           'scrapelib>=1.0',
           'jsonschema>=2.6.0',
-          'psycopg2',
+          'psycopg2-binary',
           'pytz',
       ],
       extras_require={


### PR DESCRIPTION
Lots of user warnings like this when running pupa in openstates:

```
/opt/openstates/venv-pupa/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: 
The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing 
from binary please use "pip install psycopg2-binary" instead. For details see: 
<http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```

Docs: http://initd.org/psycopg/docs/install.html#binary-install-from-pypi