### PR TITLE
Pin jsonschema to compatible version

### DIFF
--- a/pupa/utils/topsort.py
+++ b/pupa/utils/topsort.py
@@ -36,7 +36,7 @@ class Network(object):
 
                   [ FROM ] ------> [ TO ]
         Committee on Finance -> Subcommittee of the Finance Committee on Budget
-                            \-> Subcommittee of the Finance Committee on Roads
+                             -> Subcommittee of the Finance Committee on Roads
         """
         self.add_node(fro)
         self.add_node(to)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ pupa = pupa.cli.__main__:main''',
           'opencivicdata>=2.1.0',
           'dj_database_url>=0.3.0',
           'scrapelib>=1.0',
-          'jsonschema>=2.6.0',
+          'jsonschema>=3.0.0a1',  # TODO: Drop alpha release once stable release is available
           'psycopg2-binary',
           'pytz',
       ],


### PR DESCRIPTION
Looks like we're using jsonschema 3.x. This pins the install to use the latest version. We should drop the alpha release once a stable release is out.