### PR TITLE
Apply order to VoteEvents.

### DIFF
--- a/pupa/scrape/__init__.py
+++ b/pupa/scrape/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from .jurisdiction import Jurisdiction, JurisdictionScraper
 from .popolo import Membership, Organization, Person, Post
-from .vote_event import VoteEvent
+from .vote_event import VoteEvent, OrderVoteEvent
 from .bill import Bill
 from .event import Event
 from .base import Scraper, BaseBillScraper

--- a/pupa/scrape/vote_event.py
+++ b/pupa/scrape/vote_event.py
@@ -6,6 +6,7 @@ from .schemas.vote_event import schema
 from pupa.exceptions import ScrapeValueError
 import re
 
+
 class VoteEvent(BaseModel, SourceMixin):
     _type = 'vote_event'
     _schema = schema
@@ -108,7 +109,7 @@ class OrderVoteEvent:
 
             self.order += 1
             voteEvent.start_date = self._adjust_date(voteEvent.start_date)
-            if hasattr(voteEvent,'end_date'):
+            if hasattr(voteEvent, 'end_date'):
                 voteEvent.end_date = self._adjust_date(voteEvent.end_date)
 
         def _adjust_date(self, date):
@@ -147,7 +148,7 @@ class OrderVoteEvent:
         :param voteEvent:
         :return: None
         """
-        bill_orderer = self.orderers.get((session_id,bill_id))
+        bill_orderer = self.orderers.get((session_id, bill_id))
 
         if not bill_orderer:
             bill_orderer = self.OrderBillVoteEvent()

--- a/pupa/scrape/vote_event.py
+++ b/pupa/scrape/vote_event.py
@@ -4,7 +4,7 @@ from .bill import Bill
 from .popolo import pseudo_organization
 from .schemas.vote_event import schema
 from pupa.exceptions import ScrapeValueError
-
+import re
 
 class VoteEvent(BaseModel, SourceMixin):
     _type = 'vote_event'
@@ -74,3 +74,70 @@ class VoteEvent(BaseModel, SourceMixin):
                 break
         else:
             self.counts.append({'option': option, 'value': value})
+
+
+class OrderVoteEvent:
+    """ A functor for applying order to voteEvents.
+        A new functor object must be constructed for each bill.
+        The vote events of each billl must be processed in chronological order for this to work
+        correctly, but the processing of bills may be interleaved (needed in e.g. NH).
+        Currently, it only fudges midnight dates by adding the event sequence number in seconds
+            to the start_date and end_date (if they are well-formed string dates)
+        In the future, if and when there is an 'order' field on voteEvents,
+            it should fill that as well.
+        This fails softly and silently;
+            if a valid string date is not found in start_date or end_date,
+            the date is left unmodified
+        See the unit tests for more behavior expectations.
+    """
+    _midnight = r'\d\d\d\d-\d\d-\d\dT00:00:00.*'
+    _timeless = r'\d\d\d\d-\d\d-\d\d'
+
+
+    class OrderBillVoteEvent:
+        """ Order VoteEvents for a single bill
+        """
+
+        def __init__(self):
+            self.order = 0      # voteEvent sequence number. 1st voteEvent is 1.
+
+        def __call__(self, voteEvent):
+
+            self.order += 1
+            voteEvent.start_date = self._adjust_date(voteEvent.start_date)
+            voteEvent.end_date = self._adjust_date(voteEvent.end_date)
+
+        def _adjust_date(self, date):
+
+            if not isinstance(date, str):
+                return date
+
+            if re.fullmatch(OrderVoteEvent._timeless, date):
+                d2 = date + 'T00:00:00'
+            elif re.fullmatch(OrderVoteEvent._midnight, date):
+                d2 = date
+            else:
+                return date
+
+            assert self.order <= 60*60
+            mins = '{:02d}'.format(self.order // 60)
+            secs = '{:02d}'.format(self.order % 60)
+
+            # yyyy-mm-ddThh:mm:dd+05:00
+            # 0123456789012345678
+            return d2[:14] + mins + ':' + secs + d2[19:]
+
+    def __init__(self):
+        self.orderers = {}
+
+    def __call__(self, bill_id, voteEvent):
+        bill_orderer = self.orderers.get(bill_id)
+
+        if not bill_orderer:
+            bill_orderer = self.OrderBillVoteEvent()
+            self.orderers[bill_id] = bill_orderer
+
+        bill_orderer(voteEvent)
+
+
+

--- a/pupa/tests/scrape/test_vote_event_scrape.py
+++ b/pupa/tests/scrape/test_vote_event_scrape.py
@@ -1,7 +1,6 @@
 import pytest
-from pupa.scrape import VoteEvent, Bill, Organization
+from pupa.scrape import VoteEvent, Bill, Organization, OrderVoteEvent
 from pupa.utils import get_pseudo_id
-
 
 def toy_vote_event():
     ve = VoteEvent(legislative_session="2009", motion_text="passage of the bill",
@@ -95,3 +94,44 @@ def test_str():
     s = str(ve)
     assert ve.legislative_session in s
     assert ve.motion_text in s
+
+
+
+def test_order_vote_event():
+    ve = toy_vote_event()
+    order_vote_event = OrderVoteEvent()
+
+    # add order as seconds to date with no time
+    ve.start_date = '2019-01-01'
+    ve.end_date = None
+    order_vote_event('1', ve)
+    assert ve.start_date == '2019-01-01T00:00:01'
+    assert ve.end_date is None
+
+    # add order as seconds to time with explicit midnight time and zone, preserving timezone
+    ve.start_date = '2019-01-01T00:00:00+05:00'
+    ve.end_date = ''
+    order_vote_event('1', ve)
+    assert ve.start_date == '2019-01-01T00:00:02+05:00'
+    assert ve.end_date == ''
+
+    # a second bill should start with '00:00:01' again
+    ve.start_date = '2019-01-01'
+    ve.end_date = None
+    order_vote_event('2', ve)
+    assert ve.start_date == '2019-01-01T00:00:01'
+    assert ve.end_date is None
+
+    # add order as seconds to time with explicit midnight time and no timezone
+    ve.start_date = ve.end_date = '2019-01-01T00:00:00'
+    order_vote_event('1', ve)
+    assert ve.start_date == '2019-01-01T00:00:03'
+    assert ve.end_date == '2019-01-01T00:00:03'
+
+    # don't change a date with a non-midnight time
+    ve.start_date = '2019-01-01T00:00:55+05:00'
+    order_vote_event('1', ve)
+    assert ve.start_date == '2019-01-01T00:00:55+05:00'
+
+
+

--- a/pupa/tests/scrape/test_vote_event_scrape.py
+++ b/pupa/tests/scrape/test_vote_event_scrape.py
@@ -2,6 +2,7 @@ import pytest
 from pupa.scrape import VoteEvent, Bill, Organization, OrderVoteEvent
 from pupa.utils import get_pseudo_id
 
+
 def toy_vote_event():
     ve = VoteEvent(legislative_session="2009", motion_text="passage of the bill",
                    start_date="2009-01-07", result='pass', classification='bill-passage')
@@ -96,7 +97,6 @@ def test_str():
     assert ve.motion_text in s
 
 
-
 def test_order_vote_event():
     ve = toy_vote_event()
     order_vote_event = OrderVoteEvent()
@@ -139,6 +139,3 @@ def test_order_vote_event():
     ve.start_date = '2019-01-01T00:00:55+05:00'
     order_vote_event('2019', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:55+05:00'
-
-
-

--- a/pupa/tests/scrape/test_vote_event_scrape.py
+++ b/pupa/tests/scrape/test_vote_event_scrape.py
@@ -104,33 +104,40 @@ def test_order_vote_event():
     # add order as seconds to date with no time
     ve.start_date = '2019-01-01'
     ve.end_date = None
-    order_vote_event('1', ve)
+    order_vote_event('2019', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:01'
     assert ve.end_date is None
 
     # add order as seconds to time with explicit midnight time and zone, preserving timezone
     ve.start_date = '2019-01-01T00:00:00+05:00'
     ve.end_date = ''
-    order_vote_event('1', ve)
+    order_vote_event('2019', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:02+05:00'
     assert ve.end_date == ''
 
     # a second bill should start with '00:00:01' again
     ve.start_date = '2019-01-01'
     ve.end_date = None
-    order_vote_event('2', ve)
+    order_vote_event('2019', '2', ve)
+    assert ve.start_date == '2019-01-01T00:00:01'
+    assert ve.end_date is None
+
+    # the same bill id in a different session should start with '00:00:01' again
+    ve.start_date = '2019-01-01'
+    ve.end_date = None
+    order_vote_event('2020', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:01'
     assert ve.end_date is None
 
     # add order as seconds to time with explicit midnight time and no timezone
     ve.start_date = ve.end_date = '2019-01-01T00:00:00'
-    order_vote_event('1', ve)
+    order_vote_event('2019', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:03'
     assert ve.end_date == '2019-01-01T00:00:03'
 
     # don't change a date with a non-midnight time
     ve.start_date = '2019-01-01T00:00:55+05:00'
-    order_vote_event('1', ve)
+    order_vote_event('2019', '1', ve)
     assert ve.start_date == '2019-01-01T00:00:55+05:00'
 
 


### PR DESCRIPTION
OpenStates `VoteEvent`s are often impossible to order within a given day, because chambers often provide the date of a vote without a time of day, and because the OCD `VoteEvent` definition does not provide an `order` field similar to `BillAction`.

This PR provides a scraper-based stopgap means of ordering votes, by adding an `order` value in seconds to `start_date` and `end_date`, when they have no time-of-day component.  A scraper creates a single instance of `OrderVoteEvent` (herein) and then passing each VoteEvent through it before emitting. 

When and if an "order" value is added to VoteEvent, it could be filled by this as well.  I'll start on that shortly and see how it goes.

This has been tested _in situ_ with only a single state, New Hampshire, but I hope and believe the usage pattern is applicable to all scraper designs.