### PR TITLE
Set date on event documents and event media links

### DIFF
--- a/pupa/scrape/base.py
+++ b/pupa/scrape/base.py
@@ -186,6 +186,11 @@ class BaseModel(object):
         type_checker = Draft3Validator.TYPE_CHECKER.redefine(
             "datetime", lambda c, d: isinstance(d, (datetime.date, datetime.datetime))
         )
+        type_checker = type_checker.redefine(
+            "date", lambda c, d: (isinstance(d, datetime.date)
+                                  and not isinstance(d, datetime.datetime))
+        )
+
         ValidatorCls = jsonschema.validators.extend(Draft3Validator, type_checker=type_checker)
         validator = ValidatorCls(schema, format_checker=FormatChecker())
 

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -123,8 +123,8 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
     def add_media_link(self, note, url, media_type, *, text='', type='media',
                        on_duplicate='error', date=''):
         return self._add_associated_link(collection='media', note=note, url=url, text=text,
-                                         media_type=media_type, on_duplicate=on_duplicate)
+                                         media_type=media_type, on_duplicate=on_duplicate, date=date)
 
     def add_document(self, note, url, *, text='', media_type='', on_duplicate='error', date=''):
         return self._add_associated_link(collection='documents', note=note, url=url, text=text,
-                                         media_type=media_type, on_duplicate=on_duplicate)
+                                         media_type=media_type, on_duplicate=on_duplicate, date=date)

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -120,11 +120,20 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         self.agenda.append(obj)
         return obj
 
-    def add_media_link(self, note, url, media_type, *, text='', type='media',
-                       on_duplicate='error', date=''):
-        return self._add_associated_link(collection='media', note=note, url=url, text=text,
-                                         media_type=media_type, on_duplicate=on_duplicate, date=date)
+    def add_media_link(self, note, url, media_type, *, text='',
+                       type='media', on_duplicate='error', date=''):
+        return self._add_associated_link(collection='media',
+                                         note=note,
+                                         url=url,
+                                         text=text,
+                                         media_type=media_type,
+                                         on_duplicate=on_duplicate,
+                                         date=date)
 
     def add_document(self, note, url, *, text='', media_type='', on_duplicate='error', date=''):
-        return self._add_associated_link(collection='documents', note=note, url=url, text=text,
-                                         media_type=media_type, on_duplicate=on_duplicate, date=date)
+        return self._add_associated_link(collection='documents',
+                                         note=note, url=url,
+                                         text=text,
+                                         media_type=media_type,
+                                         on_duplicate=on_duplicate,
+                                         date=date)

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -121,10 +121,10 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         return obj
 
     def add_media_link(self, note, url, media_type, *, text='', type='media',
-                       on_duplicate='error'):
+                       on_duplicate='error', date=''):
         return self._add_associated_link(collection='media', note=note, url=url, text=text,
                                          media_type=media_type, on_duplicate=on_duplicate)
 
-    def add_document(self, note, url, *, text='', media_type='', on_duplicate='error'):
+    def add_document(self, note, url, *, text='', media_type='', on_duplicate='error', date=''):
         return self._add_associated_link(collection='documents', note=note, url=url, text=text,
                                          media_type=media_type, on_duplicate=on_duplicate)

--- a/pupa/scrape/schemas/common.py
+++ b/pupa/scrape/schemas/common.py
@@ -26,15 +26,15 @@ identifiers = {
 fuzzy_date_string = {"type": "string",
                      "pattern": "^[0-9]{4}(-[0-9]{2}){0,2}$"}
 fuzzy_date_string_blank = {"type": "string",
-                           "pattern": "(^[0-9]{4})?(-[0-9]{2}){0,2}$",
+                           "pattern": "^([0-9]{4})?(-[0-9]{2}){0,2}$",
                            }
 fuzzy_datetime_string_blank = {"type": "string",
                                "pattern": ("^([0-9]{4}((-[0-9]{2}){0,2}|(-[0-9]{2}){2}T"
                                            "[0-9]{2}(:[0-9]{2}){0,2}"
                                            "(Z|[+-][0-9]{2}(:[0-9]{2})?))?)?$"),
                                }
-fuzzy_date = {"type": [fuzzy_date_string, "datetime"]}
-fuzzy_date_blank = {"type": [fuzzy_date_string_blank, "datetime"]}
+fuzzy_date = {"type": [fuzzy_date_string, "date"]}
+fuzzy_date_blank = {"type": [fuzzy_date_string_blank, "date"]}
 fuzzy_datetime = {"type": [fuzzy_datetime_string_blank, "datetime"]}
 fuzzy_datetime_blank = {"type": [fuzzy_datetime_string_blank, "datetime"]}
 

--- a/pupa/scrape/schemas/event.py
+++ b/pupa/scrape/schemas/event.py
@@ -79,6 +79,7 @@ schema = {
                     "note": {"type": "string", "minLength": 1},
                     "url": {"type": "string", "minLength": 1},
                     "media_type": {"type": "string", "minLength": 1},
+                    "date": fuzzy_date_blank,
                 },
                 "type": "object"
             },


### PR DESCRIPTION
This PR closes #324 by allowing a date to be set on `add_media_link` and `add_document` methods of the Event scraper class.

This doesn't come with tests, but it doesn't quite feel like it needs tests since the underlying _add_associated_link method is already tested. 

I've also fixed up the schema for fuzzy_date_blank which had a bad regex and which also permitted datetimes. This does seem like something that we might want to test, but we don't have any tests for schemas that I could find.

Please advise @jamesturk .