### PR TITLE
Run all scrapers on pupa update if no defaults defined

### DIFF
--- a/pupa/scrape/jurisdiction.py
+++ b/pupa/scrape/jurisdiction.py
@@ -20,7 +20,7 @@ class Jurisdiction(BaseModel):
 
     # non-db properties
     scrapers = {}
-    default_scrapers = {}
+    default_scrapers = None
     parties = []
     ignored_scraped_sessions = []
 


### PR DESCRIPTION
## Description

This PR changes `default_scrapers` from an empty dictionary to None on the base Jurisdiction class. 

I made this change to restore fallback behavior for bare `pupa update` commands, i.e., run all scrapers if no defaults are defined. This seems to be the intention of the code, however 
because `default_scrapers` is defined as an empty dict, bare commands fall into the second conditional block (`default_scrapers` is not None), rather than the final `else` block.

https://github.com/opencivicdata/pupa/blob/ab0fa5d9a5912d0347bdc1d67e854920b8a46c3d/pupa/cli/commands/update.py#L280-L307

### Also...

Thank you so much for all your hard work on `pupa`! 🐛