### PR TITLE
Use family name when resolving person entities

### DIFF
--- a/pupa/importers/people.py
+++ b/pupa/importers/people.py
@@ -41,8 +41,9 @@ class PersonImporter(BaseImporter):
         the resolution.
         """
         if list(spec.keys()) == ['name']:
-            # if we're just resolving on name, include other names
-            return ((Q(name=spec['name']) | Q(other_names__name=spec['name'])) &
+            # if we're just resolving on name, include other names and family name
+            name = spec['name']
+            return ((Q(name=name) | Q(other_names__name=name) | Q(family_name=name)) &
                     Q(memberships__organization__jurisdiction_id=self.jurisdiction_id))
         spec['memberships__organization__jurisdiction_id'] = self.jurisdiction_id
         return spec


### PR DESCRIPTION
Some entities that need people resolution (primarily bill actions) will frequently have last names only, and not a full name. Since we might have a family name for a person, attempt to use this as well when resolving a person.

See https://github.com/openstates/openstates/issues/3102. This might not be helpful with common last names (e.g. Smith), so perhaps a more complex logic for those cases would be better (matching legislator start/end dates to vote dates?).