### PR TITLE
Add support for post-save signals that depend on related objects

### DIFF
--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -5,6 +5,7 @@ import json
 import logging
 
 from django.db.models import Q
+from django.db.models.signals import post_save
 from django.contrib.contenttypes.models import ContentType
 
 from opencivicdata.legislative.models import LegislativeSession
@@ -293,9 +294,9 @@ class BaseImporter(object):
                                                                            self.model_class))
             self._create_related(obj, related, self.related_models)
 
-            # Save object after related objects are created to allow for
-            # post-save signals that depend on related objects
-            obj.save()
+            # Fire post-save signal after related objects are created to allow
+            # for handlers make use of related objects
+            post_save.send(sender=self.model_class, instance=obj, created=True)
 
         if pupa_id:
             Identifier.objects.get_or_create(identifier=pupa_id,

--- a/pupa/importers/base.py
+++ b/pupa/importers/base.py
@@ -293,6 +293,10 @@ class BaseImporter(object):
                                                                            self.model_class))
             self._create_related(obj, related, self.related_models)
 
+            # Save object after related objects are created to allow for
+            # post-save signals that depend on related objects
+            obj.save()
+
         if pupa_id:
             Identifier.objects.get_or_create(identifier=pupa_id,
                                              jurisdiction_id=self.jurisdiction_id,


### PR DESCRIPTION
### Description

This PR adds a line to save new objects after related objects are created. This allows use of [Django's `post_save` signal](https://docs.djangoproject.com/en/2.2/ref/signals/#post-save) to perform operations that depend on related objects. 

Take our use case as an example: We want to [use some custom logic](https://github.com/datamade/django-councilmatic/pull/264) to determine a bill's last action date. This logic depends on two types of related objects, bill actions and event related entities. The change in this PR allows us to query related objects after `Event` and `Bill` save in order to determine the appropriate last action date.

As ever, thanks for your work!