### PR TITLE
make location_name optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _data/
 _cache/
 build/
 .cache/
+.env/

--- a/pupa/importers/events.py
+++ b/pupa/importers/events.py
@@ -63,7 +63,8 @@ class EventImporter(BaseImporter):
 
     def prepare_for_db(self, data):
         data['jurisdiction_id'] = self.jurisdiction_id
-        data['location'] = self.get_location(data['location'])
+        if data['location']:
+            data['location'] = self.get_location(data['location'])
 
         data['start_date'] = data['start_date']
         data['end_date'] = data.get('end_date', "")

--- a/pupa/scrape/event.py
+++ b/pupa/scrape/event.py
@@ -71,7 +71,8 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
     _type = 'event'
     _schema = schema
 
-    def __init__(self, name, start_date, location_name, *,
+    def __init__(self, name, start_date, *,
+                 location_name=None,
                  all_day=False, description="", end_date="",
                  status="confirmed", classification="event"
                  ):
@@ -83,7 +84,8 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         self.description = description
         self.status = status
         self.classification = classification
-        self.location = {"name": location_name, "note": "", "coordinates": None}
+        if location_name:
+            self.location = {"name": location_name, "note": "", "coordinates": None}
         self.documents = []
         self.participants = []
         self.media = []

--- a/pupa/scrape/schemas/event.py
+++ b/pupa/scrape/schemas/event.py
@@ -41,7 +41,7 @@ schema = {
         "description": {"type": "string"},
 
         "location": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
 
                 "name": {"type": "string", "minLength": 1},

--- a/pupa/tests/importers/test_event_importer.py
+++ b/pupa/tests/importers/test_event_importer.py
@@ -206,6 +206,10 @@ def test_full_event():
     result = EventImporter('jid', oi, pi, bi, vei).import_data([event.as_dict()])
     assert result['event']['update'] == 1
 
+    event.location = None
+    result = EventImporter('jid', oi, pi, bi, vei).import_data([event.as_dict()])
+    assert result['event']['update'] == 1
+
 
 @pytest.mark.django_db
 def test_pupa_identifier_event():

--- a/pupa/tests/scrape/test_event_scrape.py
+++ b/pupa/tests/scrape/test_event_scrape.py
@@ -18,6 +18,15 @@ def test_basic_event():
     e.validate()
 
 
+def test_no_location():
+    e = Event(
+        name="get-together",
+        start_date=datetime.datetime.utcnow().isoformat().split('.')[0] + 'Z',
+    )
+    e.add_source(url='http://example.com/foobar')
+    e.validate()
+
+
 def test_event_str():
     e = event_obj()
     assert e.name in str(e)


### PR DESCRIPTION
sometimes events don't have physical locations (like remote meetings). this makes "location_name" an optional arg for the Event class