### PR TITLE
Default to resolving memberships by start date, fall back to end date

### DIFF
--- a/pupa/importers/memberships.py
+++ b/pupa/importers/memberships.py
@@ -22,9 +22,7 @@ class MembershipImporter(BaseImporter):
         spec = {'organization_id': membership['organization_id'],
                 'person_id': membership['person_id'],
                 'label': membership['label'],
-                'role': membership['role'],
-                # if this is a historical role, only update historical roles
-                'end_date': membership['end_date']}
+                'role': membership['role']}
 
         # post_id is optional - might exist in DB but not scraped here?
         if membership['post_id']:
@@ -32,6 +30,12 @@ class MembershipImporter(BaseImporter):
 
         if membership['person_name']:
             spec['person_name'] = membership['person_name']
+
+        if membership['start_date']:
+            spec['start_date'] = membership['start_date']
+        else:
+            # if this is a historical role, only update historical roles
+            spec['end_date'] = membership['end_date']
 
         return self.model_class.objects.get(**spec)
 

--- a/pupa/tests/importers/test_membership_importer.py
+++ b/pupa/tests/importers/test_membership_importer.py
@@ -30,7 +30,7 @@ def test_full_membership():
 
     # add a membership through a post, with a start date
     m1 = ScrapeMembership(person_id=hari.id, organization_id=org.id,
-                          post_id=post.id, start_date='2020-03-10')
+                          post_id=post.id, start_date='2020-03-10', end_date='2021-06-30')
     m1.add_contact_detail(type='phone', value='555-555-1234', note='this is fake')
     m1.add_link('http://example.com/link')
 
@@ -68,9 +68,11 @@ def test_full_membership():
     assert import_log['membership']['insert'] == 0
     assert import_log['membership']['update'] == 2
 
+    # confirm the membership resolved based on start date and its end date was updated
     assert hari.memberships.count() == 1
     assert hari.memberships.get().end_date == '2022-03-10'
 
+    # confirm the membership resolved based on end date and its extras were updated
     assert robot.memberships.count() == 1
     assert robot.memberships.get().extras == {'note': 'bleep blorp'}
 


### PR DESCRIPTION
## Description

This PR updates the membership import spec, such that if a membership has a start date, `pupa` will use it to resolve the incoming membership with an existing membership. Otherwise, it will fall back to end date, which was the original default, preserved here to handle historic memberships as mentioned in https://github.com/opencivicdata/pupa/issues/303#issuecomment-358778411.