### PR TITLE
Add logging to pupa clean failsafe

### DIFF
--- a/pupa/cli/commands/clean.py
+++ b/pupa/cli/commands/clean.py
@@ -88,15 +88,17 @@ class Command(BaseCommand):
             )
             self.report_stale_objects()
         else:
-            num_stale_objects = len(list(self.get_stale_objects(args.window)))
+            stale_objects = list(self.get_stale_objects(args.window))
+            num_stale_objects = len(stale_objects)
 
             if args.noinput:
                 # Fail-safe to avoid deleting a large amount of objects
                 # without explicit confimation
                 if num_stale_objects > 10:
                     print(
-                        "This command would delete more than 10 objects."
-                        "If you're sure, re-run without --noinput to provide confirmation."
+                        f"This command would delete {num_stale_objects} objects: "
+                        f"\n{stale_objects}"
+                        "\nIf you're sure, re-run without --noinput to provide confirmation."
                     )
                     sys.exit(1)
             else:

--- a/pupa/cli/commands/clean.py
+++ b/pupa/cli/commands/clean.py
@@ -44,6 +44,11 @@ class Command(BaseCommand):
             action="store_true",
             help="delete objects without getting user confirmation",
         )
+        self.add_argument(
+            "--yes",
+            action="store_true",
+            help="delete objects without getting user confirmation",
+        )
 
     def get_stale_objects(self, window):
         """
@@ -94,11 +99,12 @@ class Command(BaseCommand):
             if args.noinput:
                 # Fail-safe to avoid deleting a large amount of objects
                 # without explicit confimation
-                if num_stale_objects > 10:
+                if num_stale_objects > 10 and not args.yes:
                     print(
                         f"This command would delete {num_stale_objects} objects: "
                         f"\n{stale_objects}"
                         "\nIf you're sure, re-run without --noinput to provide confirmation."
+                        "\nOr re-run with --yes to assume a yes answer to all prompts."
                     )
                     sys.exit(1)
             else:

--- a/pupa/cli/commands/clean.py
+++ b/pupa/cli/commands/clean.py
@@ -47,7 +47,8 @@ class Command(BaseCommand):
         self.add_argument(
             "--yes",
             action="store_true",
-            help="delete objects without getting user confirmation",
+            help="assumes an answer of 'yes' to all interactive prompts",
+            default=False,
         )
 
     def get_stale_objects(self, window):
@@ -96,10 +97,14 @@ class Command(BaseCommand):
             stale_objects = list(self.get_stale_objects(args.window))
             num_stale_objects = len(stale_objects)
 
+            if args.noinput and args.yes:
+                self.remove_stale_objects(args.window)
+                sys.exit()
+
             if args.noinput:
                 # Fail-safe to avoid deleting a large amount of objects
                 # without explicit confimation
-                if num_stale_objects > 10 and not args.yes:
+                if num_stale_objects > 10:
                     print(
                         f"This command would delete {num_stale_objects} objects: "
                         f"\n{stale_objects}"

--- a/pupa/tests/clean/test_clean.py
+++ b/pupa/tests/clean/test_clean.py
@@ -85,7 +85,7 @@ def test_clean_command(subparsers):
 
         # Call clean command
         Command(subparsers).handle(
-            argparse.Namespace(noinput=True, report=False, window=7), []
+            argparse.Namespace(noinput=True, report=False, window=7, yes=False), []
         )
 
         expected_stale_objects = {stale_person, stale_membership}
@@ -117,5 +117,5 @@ def test_clean_command_failsafe(subparsers):
         with pytest.raises(SystemExit):
             # Should trigger failsafe exist when deleting more than 10 objects
             Command(subparsers).handle(
-                argparse.Namespace(noinput=True, report=False, window=7), []
+                argparse.Namespace(noinput=True, report=False, window=7, yes=False), []
             )


### PR DESCRIPTION
## Overview

This PR adds logging to the `pupa clean` CLI command. When the failsafe is triggered, we'll also output the stale database objects that were found.